### PR TITLE
Privacy test pages - small fixes

### DIFF
--- a/privacy-protections/https-upgrades/main.js
+++ b/privacy-protections/https-upgrades/main.js
@@ -68,8 +68,7 @@ const tests = [
         id: 'upgrade-subrequest',
         run: () => {
             return fetch(`http://${TEST_DOMAIN}/reflect-headers`)
-                .then(r => r.json())
-                .then(data => data.url);
+                .then(r => r.url);
         }
     },
     {

--- a/privacy-protections/storage-blocking/main.js
+++ b/privacy-protections/storage-blocking/main.js
@@ -249,7 +249,7 @@ function retrieveData() {
         testsSummaryDiv.innerText = `Retrieved data from ${all} storage mechanisms${failed > 0 ? ` (${failed} failed)` : ''}. Click for details.`;
     }
 
-    tests.forEach(test => {
+    tests.concat(commonTests).forEach(test => {
         all++;
 
         const resultObj = {

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 
 function fullUrl(req) {
   return url.format({
+    // note: if server is behind a proxy, and it probably is, you may see 'http' here even if request was 'https'
     protocol: req.protocol,
     host: req.get('host'),
     pathname: req.originalUrl


### PR DESCRIPTION
Storage test page was not retrieving data from all the places we were saving the data to.
HTTPS test page was not reporting correctly subrequest updates because server may not know if connection was http or https if it's behind a proxy (and that's usually the case).