### PR TITLE
Request Blocking - improve detection of loaded request

### DIFF
--- a/privacy-protections/request-blocking/main.js
+++ b/privacy-protections/request-blocking/main.js
@@ -211,7 +211,7 @@ const tests = [
 
             const checkResource = resource => {
                 if (resource.name.includes('cssbg.jpg')) {
-                    if (resource.duration === 0 && resource.nextHopProtocol === '') {
+                    if (resource.serverTiming.length === 0) {
                         callback('failed');
                     } else {
                         callback('loaded');
@@ -309,7 +309,7 @@ const tests = [
 
             const checkResource = resource => {
                 if (resource.name.includes('favicon.ico?')) {
-                    if (resource.duration === 0 && resource.nextHopProtocol === '') {
+                    if (resource.serverTiming.length === 0) {
                         callback('failed');
                     } else {
                         callback('loaded');
@@ -423,7 +423,7 @@ const tests = [
 
             const checkResource = resource => {
                 if (resource.name.includes('/csp')) {
-                    if (resource.duration === 0 && resource.nextHopProtocol === '') {
+                    if (resource.serverTiming.length === 0) {
                         callback('failed');
                     } else {
                         callback('loaded');

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ app.use(express.static('.', {
     setHeaders: (res, path) => {
         res.set('Access-Control-Allow-Origin', '*');
         res.set('Timing-Allow-Origin', '*');
+        res.set('Server-Timing', 'loaded');
 
         // send CSP header when fetching request blocking test site
         if (path.endsWith('privacy-protections/request-blocking/index.html')) {
@@ -90,6 +91,7 @@ app.get('/block-me/server-sent-events', (req, res) => {
 // dummy CSP report endopoint
 app.post('/block-me/csp', (req, res) => {
     res.set('Timing-Allow-Origin', '*');
+    res.set('Server-Timing', 'loaded');
     return res.sendStatus(200);
 });
 


### PR DESCRIPTION
Decide if request has loaded or not by looking at the server-timing data instead of duration and protocol (which were a bit unreliable in some browsers).