### PR TITLE
Add page for logging various API stack traces.

### DIFF
--- a/features/stack-tracing/index.html
+++ b/features/stack-tracing/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Stack tracing</title>
+</head>
+<body>
+<p><a href="../../index.html">[Home]</a></p>
+
+<p>This test page writes out various test stack traces as they are slightly different per browser.</p>
+
+<style>
+  #error-output {
+    overflow: scroll;
+    border: 1px solid #000;
+  }
+  #error-output dl {
+    margin: 1rem;
+  }
+  #error-output dd {
+    white-space: pre;
+  }
+</style>
+
+<p>Error stack trace output:</p>
+<div id="error-output">
+</div>
+
+<script>
+  let errorOutput = document.getElementById('error-output');
+  function log(source, stackValue) {
+    let valueElement = document.createElement('dl');
+
+    let dtElement = document.createElement('dt');
+    dtElement.textContent = source;
+    dtElement.title = 'Source of stack trace';
+    valueElement.appendChild(dtElement);
+
+    let ddElement = document.createElement('dd');
+    ddElement.textContent = stackValue;
+    ddElement.title = 'Stack trace value';
+    valueElement.appendChild(ddElement);
+
+    errorOutput.appendChild(valueElement);
+  }
+  let sourceName = 'HTML <script>';
+  log(sourceName, new Error().stack);
+  setTimeout(() => {
+    log(`${sourceName} setTimeout`, new Error().stack);
+  }, 0)
+</script>
+
+<script src="./script.js"></script>
+<script>
+  const TEST_DOMAIN = `${window.location.protocol}//good.third-party.site`;
+  document.write(`<script src="${TEST_DOMAIN}/features/stack-tracing/script.js"></${'script'}>`);
+</script>
+
+</body>
+</html>

--- a/features/stack-tracing/script.js
+++ b/features/stack-tracing/script.js
@@ -1,0 +1,20 @@
+(() => {
+  let base = new URL(document.currentScript.src);
+  let party = base.origin == window.top.location.origin ? 'first' : 'third';
+  let scriptName = `${party} party script`;
+
+  log(scriptName, new Error().stack);
+
+  let worker = new Worker('./worker.js');
+  worker.addEventListener('message', msg => {
+    let { source, stackValue } = msg.data;
+    log(`${scriptName} loading ${source}`, stackValue);
+  });
+  worker.postMessage({ action: 'setup' });
+
+  setTimeout(() => {
+    log(`${scriptName} setTimeout`, new Error().stack);
+  }, 0)
+
+  document.write(`<script>log('${scriptName} write', new Error().stack);</script>`);
+})();

--- a/features/stack-tracing/worker.js
+++ b/features/stack-tracing/worker.js
@@ -1,0 +1,17 @@
+function log(source, stackValue) {
+  postMessage({ source, stackValue });
+}
+
+self.addEventListener('message', msg => {
+  if (msg.data.action && msg.data.action === 'setup') {
+    setup();
+  }
+});
+
+function setup() {
+  log("worker", new Error().stack)
+
+  setTimeout(() => {
+    log("worker setTimeout", new Error().stack)
+  }, 0);
+}

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 	<li><a href="./features/closeable.html">window.close() Link</a></li>
 	<li><a href="./features/text-editing.html">Simple text area for editing</a></li>
 	<li><a href="./features/url-schemes.html">URL Schemes</a></li>
+	<li><a href="./features/stack-tracing/">Stack tracing</a></li>
 </ul>
 
 <h2>Security</h2>


### PR DESCRIPTION
This has been useful in debugging stack traces across browsers, it's by no means comprehensive but illustrates the differences.

Also to note when sitea.com -> siteb.evil/script.js -> sitea.com/worker.js is loaded the stack never illustrates what loaded the worker.