### PR TITLE
Add storage test for cookies set from a 3rd party script.

### DIFF
--- a/privacy-protections/storage-blocking/3rdparty.js
+++ b/privacy-protections/storage-blocking/3rdparty.js
@@ -1,0 +1,15 @@
+/**
+ * document.cookie test run in a 3rd party script.
+ * 
+ * As we load this script via a 3rd party origin in the test, when running `store` the 3rd party
+ * origin will be visible in the call stack to document.cookie.
+ */
+tests.push({
+    id: 'JS cookie (3rd party script)',
+    store: (data) => {
+        document.cookie = `tpdata=${data}; expires= Wed, 21 Aug 2030 20:00:00 UTC;`;
+    },
+    retrive: () => {
+        return document.cookie.match(/tpdata\=([0-9]+)/)[1];
+    }
+});

--- a/privacy-protections/storage-blocking/3rdparty.js
+++ b/privacy-protections/storage-blocking/3rdparty.js
@@ -4,7 +4,7 @@
  * As we load this script via a 3rd party origin in the test, when running `store` the 3rd party
  * origin will be visible in the call stack to document.cookie.
  */
-tests.push({
+commonTests.push({
     id: 'JS cookie (3rd party script)',
     store: (data) => {
         document.cookie = `tpdata=${data}; expires= Wed, 21 Aug 2030 20:00:00 UTC;`;

--- a/privacy-protections/storage-blocking/index.html
+++ b/privacy-protections/storage-blocking/index.html
@@ -7,8 +7,8 @@
 
     <script src='./helpers/idb-wrapper.js' defer></script>
     <script src='./helpers/commonTests.js'></script>
-    <script src='./main.js' defer></script>
     <script src='https://good.third-party.site/privacy-protections/storage-blocking/3rdparty.js' defer></script>
+    <script src='./main.js' defer></script>
     <link href='./style.css' rel='stylesheet'></link>
 </head>
 <body>

--- a/privacy-protections/storage-blocking/index.html
+++ b/privacy-protections/storage-blocking/index.html
@@ -8,6 +8,7 @@
     <script src='./helpers/idb-wrapper.js' defer></script>
     <script src='./helpers/commonTests.js'></script>
     <script src='./main.js' defer></script>
+    <script src='https://good.third-party.site/privacy-protections/storage-blocking/3rdparty.js' defer></script>
     <link href='./style.css' rel='stylesheet'></link>
 </head>
 <body>


### PR DESCRIPTION
Adds a new storage test for when `document.cookie` is set from a script which was loaded from a 3rd party origin.