### PR TITLE
Update observer to check duration and filter failed loads

### DIFF
--- a/privacy-protections/click-to-load/index.html
+++ b/privacy-protections/click-to-load/index.html
@@ -97,7 +97,15 @@ function facebookObserver (list, observer) {
     const resourceLoads = list.getEntriesByType('resource');
     for (const resource of resourceLoads) {
         if (resource.name.match(/facebook.com|facebook.net/)) {
-            facebookCalls += 1;
+            /* Observer still counts calls that fail, but the duration is less. In testing,
+             * failed iFrames always returned in around 100 or less, with success generally being
+             * above 200. Occasionally, a loaded resource comes in around 150. If Facebook requests
+             * are allowed, there will also be other resources that load - scripts and content
+             * which will always be counted.
+            */
+            if (resource.initiatorType !== 'iframe' || resource.duration > 150) {
+                facebookCalls += 1;
+            }
         }
     }
     displayFacebookCalls(facebookCalls);


### PR DESCRIPTION
This adds additional checks to determine if a FB call actually loads. Unfortunately, there isn't a clean way to determine whether an iFrame loads content successfully. This uses timing as a proxy for that. Should fix integration tests for click to load.