### PR TITLE
Check if we can load a surrogate even if the integrity mismatches.

### DIFF
--- a/privacy-protections/surrogates/main.js
+++ b/privacy-protections/surrogates/main.js
@@ -55,6 +55,15 @@ const surrogates = {
         test: () => { return !!(window.ga && Object.keys(window.ga.create()).length === 0); },
         cleanUp: () => { delete window.ga; }
     },
+    'google-analytics.com/analytics.js broken integrity': {
+        url: 'https://google-analytics.com/analytics.js',
+        crossOrigin: 'anonymous',
+        integrity: 'sha512-1xNTXD/ZeaKg/Xjb6De9la7CXo5gC1lMk+beyKo691KJrjlj0HbZG6frzK0Wo6bm96i9Cp6w/WB4vSN/8zDBLQ==',
+        notes: 'Fails loading in all browsers despite we think it should be possible for the extension to load this.',
+        shouldFail: false,
+        test: () => { return !!(window.ga && Object.keys(window.ga.create()).length === 0); },
+        cleanUp: () => { delete window.ga; }
+    },
     'google-analytics.com/analytics.js': {
         url: 'https://google-analytics.com/analytics.js',
         shouldFail: false,
@@ -76,6 +85,9 @@ const surrogates = {
 
             if (testData.crossOrigin) {
                 s.crossOrigin = testData.crossOrigin;
+            }
+            if (testData.integrity) {
+                s.integrity = testData.integrity;
             }
 
             s.onload = () => {

--- a/privacy-protections/surrogates/main.js
+++ b/privacy-protections/surrogates/main.js
@@ -59,7 +59,7 @@ const surrogates = {
         url: 'https://google-analytics.com/analytics.js',
         crossOrigin: 'anonymous',
         integrity: 'sha512-1xNTXD/ZeaKg/Xjb6De9la7CXo5gC1lMk+beyKo691KJrjlj0HbZG6frzK0Wo6bm96i9Cp6w/WB4vSN/8zDBLQ==',
-        notes: 'Fails loading in all browsers despite we think it should be possible for the extension to load this.',
+        notes: 'Surrogate will fail to load due to integrity check. We think this check should not apply to extensions.',
         shouldFail: false,
         test: () => { return !!(window.ga && Object.keys(window.ga.create()).length === 0); },
         cleanUp: () => { delete window.ga; }


### PR DESCRIPTION
@kdzwinel / @jdorweiler  this currently fails should I set `shouldFail` to true?

The idea here is we would like the browser to permit us loading a surrogate when the SRI check doesn't match. This would allow us to have surrogates for the likes of fingerprint.js and f***Adblock etc.

My hope is we can direct Chrome/Firefox etc at this page when we raise issues.