### PR TITLE
Use broken.third-party.site instead of bad.third-party.site for referrer trimming test

### DIFF
--- a/privacy-protections/referrer-trimming/main.js
+++ b/privacy-protections/referrer-trimming/main.js
@@ -110,7 +110,7 @@ const tests = [
     {
         id: '3p tracker request',
         run: () => {
-            return fetch('https://bad.third-party.site/reflect-headers')
+            return fetch('https://broken.third-party.site/reflect-headers')
                 .then(r => r.json())
                 .then(data => data.headers.referer);
         }
@@ -125,7 +125,7 @@ const tests = [
     },
     {
         id: '3p tracker iframe',
-        run: () => generateFrameTest('https://bad.third-party.site/privacy-protections/referrer-trimming/frame.html')
+        run: () => generateFrameTest('https://broken.third-party.site/privacy-protections/referrer-trimming/frame.html')
     }
 ];
 


### PR DESCRIPTION
Needs https://github.com/duckduckgo/privacy-test-pages/pull/56 to be merged first.

https://app.asana.com/0/1186013049913869/1200339587157297/f