### PR TITLE
Loop protection in HTTPS upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
 	<li><a href='./privacy-protections/storage-blocking/'>Storage blocking</a></li>
 	<li><a href='./privacy-protections/referrer-trimming/'>Referrer trimming</a></li>
 	<li><a href='./privacy-protections/https-upgrades/'>HTTPS upgrades</a></li>
+	<li><a href='./privacy-protections/https-loop-protection/'>HTTPS upgrade loop protection</a></li>
 	<li><a href='./privacy-protections/click-to-load/'>Facebook click to load</a></li>
 	<li><a href='./privacy-protections/surrogates/'>Surrogates</a></li>
 </ul>

--- a/privacy-protections/https-loop-protection/http-only.html
+++ b/privacy-protections/https-loop-protection/http-only.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,17 +9,27 @@
 <body>
     <script>
         const MAX = 15;
+        const LS_ITEM_KEY = 'https-loop-protection-attempt';
         const newUrl = new URL(location.href);
-        const attempt = Number(newUrl.searchParams.get('attempt')) || 0;
+        const isStart = newUrl.searchParams.has('start');
 
-        document.body.innerText += `${location.protocol} - attempt ${attempt + 1}/${MAX}. ${attempt >= MAX ? 'Gave up.' : ''}`;
+        if (isStart) {
+            localStorage[LS_ITEM_KEY] = 0;
+        }
+        const attempt = Number.parseInt(localStorage[LS_ITEM_KEY], 10);
+        localStorage[LS_ITEM_KEY] = attempt + 1;
+
+        document.body.innerHTML += `<h1>${location.protocol}</h1>`;
 
         // force http, count attempts
         if (location.protocol === 'https:' && attempt < MAX) {
+            document.body.innerHTML += `<p>Attempt ${attempt + 1}/${MAX}</p>`;
+
             newUrl.protocol = 'http:';
-            newUrl.searchParams.set('attempt', attempt + 1);
+            newUrl.searchParams.delete('start');
             location.href = newUrl.href;
         } else {
+            localStorage.removeItem(LS_ITEM_KEY);
             const onMessage = msg => {
                 if (msg.data.action && msg.data.action === 'url') {
                     if (window.opener) {

--- a/privacy-protections/https-loop-protection/http-only.html
+++ b/privacy-protections/https-loop-protection/http-only.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HTTPS upgrade loop protection</title>
+</head>
+<body>
+    <script>
+        const MAX = 15;
+        const newUrl = new URL(location.href);
+        const attempt = Number(newUrl.searchParams.get('attempt')) || 0;
+
+        document.body.innerText += `${location.protocol} - attempt ${attempt + 1}/${MAX}. ${attempt >= MAX ? 'Gave up.' : ''}`;
+
+        // force http, count attempts
+        if (location.protocol === 'https:' && attempt < MAX) {
+            newUrl.protocol = 'http:';
+            newUrl.searchParams.set('attempt', attempt + 1);
+            location.href = newUrl.href;
+        } else {
+            const onMessage = msg => {
+                if (msg.data.action && msg.data.action === 'url') {
+                    if (window.opener) {
+                        window.opener.postMessage({ url: document.location.href, type: msg.data.type }, '*');
+                    } else if (window.parent) {
+                        window.parent.postMessage({ url: document.location.href, type: msg.data.type }, '*');
+                    }
+                }
+            };
+
+            window.addEventListener('message', onMessage);
+        }
+    </script>
+</body>
+</html>

--- a/privacy-protections/https-loop-protection/index.html
+++ b/privacy-protections/https-loop-protection/index.html
@@ -11,7 +11,7 @@
 <body>
     <p><a href="../../">[Home]</a> ↣ <a href="../">[Privacy Protections Tests]</a> ↣ <strong>[HTTPS Upgrade Loop Protection]</strong></p>
 
-    <p>This tst will navigate to page on a https upgradable domain that imadiatelly redirects to its http version. This will cause a http↔http loop (client trying to upgrade, page downgrading). Clients should detect this scenario and allow page to load.</p>
+    <p>This test will navigate to page on a https upgradable domain that immediately redirects to its http version. This will cause a http↔http loop (client trying to upgrade, page downgrading). Clients should detect this scenario and allow page to load.</p>
 
     <p><button id='start'>Start test</button></p>
 

--- a/privacy-protections/https-loop-protection/index.html
+++ b/privacy-protections/https-loop-protection/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HTTPS upgrade loop protection</title>
+
+    <script src='./main.js' defer></script>
+    <link href='./style.css' rel='stylesheet'></link>
+</head>
+<body>
+    <p><a href="../../">[Home]</a> ↣ <a href="../">[Privacy Protections Tests]</a> ↣ <strong>[HTTPS Upgrade Loop Protection]</strong></p>
+
+    <p>This tst will navigate to page on a https upgradable domain that imadiatelly redirects to its http version. This will cause a http↔http loop (client trying to upgrade, page downgrading). Clients should detect this scenario and allow page to load.</p>
+
+    <p><button id='start'>Start test</button></p>
+
+    <details id='tests' hidden>
+        <summary id='tests-summary'></summary>
+        <ul id='tests-details'>
+        </ul>
+    </details>
+
+    <p><button id='download' disabled>Download the result</button></p>
+
+</body>
+</html>

--- a/privacy-protections/https-loop-protection/index.html
+++ b/privacy-protections/https-loop-protection/index.html
@@ -12,6 +12,7 @@
     <p><a href="../../">[Home]</a> ↣ <a href="../">[Privacy Protections Tests]</a> ↣ <strong>[HTTPS Upgrade Loop Protection]</strong></p>
 
     <p>This test will navigate to page on a https upgradable domain that immediately redirects to its http version. This will cause a http↔http loop (client trying to upgrade, page downgrading). Clients should detect this scenario and allow page to load.</p>
+    <p>If the loop protection works the reported url will be "http:" and not "https:".</p>
 
     <p><button id='start'>Start test</button></p>
 

--- a/privacy-protections/https-loop-protection/main.js
+++ b/privacy-protections/https-loop-protection/main.js
@@ -1,0 +1,142 @@
+const startButton = document.querySelector('#start');
+const downloadButton = document.querySelector('#download');
+
+const testsDiv = document.querySelector('#tests');
+const testsSummaryDiv = document.querySelector('#tests-summary');
+const testsDetailsDiv = document.querySelector('#tests-details');
+
+const TEST_DOMAIN = 'good.third-party.site';
+
+const tests = [
+    {
+        id: 'upgrade-navigation',
+        run: () => {
+            let res;
+            const promise = new Promise((resolve, reject) => { res = resolve; });
+            const otherWindow = window.open(`http://${TEST_DOMAIN}/privacy-protections/https-loop-protection/http-only.html`);
+
+            const interval = setInterval(() => {
+                otherWindow.postMessage({ action: 'url', type: 'navigation' }, `http://${TEST_DOMAIN}/`);
+                otherWindow.postMessage({ action: 'url', type: 'navigation' }, `https://${TEST_DOMAIN}/`);
+            }, 500);
+
+            function onMessage (m) {
+                if (m.data && m.data.type === 'navigation') {
+                    clearInterval(interval);
+                    otherWindow.close();
+                    window.removeEventListener('message', onMessage);
+                    res(m.data.url);
+                }
+            }
+
+            window.addEventListener('message', onMessage);
+
+            return promise;
+        }
+    }
+];
+
+// object that contains results of all tests
+const results = {
+    page: 'https-loop-protection',
+    date: null,
+    results: []
+};
+
+function resultToHTML (data) {
+    if (Array.isArray(data)) {
+        return `<ul>${data.map(r => `<li>${r.test} - ${r.result}</li>`).join('')}</ul>`;
+    } else if (data) {
+        return JSON.stringify(data, null, 2);
+    }
+
+    return null;
+}
+
+/**
+ * Test runner
+ */
+function runTests () {
+    startButton.setAttribute('disabled', 'disabled');
+    downloadButton.removeAttribute('disabled');
+    testsDiv.removeAttribute('hidden');
+
+    results.results.length = 0;
+    results.date = (new Date()).toUTCString();
+    let all = 0;
+    let failed = 0;
+
+    testsDetailsDiv.innerHTML = '';
+
+    function updateSummary () {
+        testsSummaryDiv.innerText = `Performed ${all} tests${failed > 0 ? ` (${failed} failed)` : ''}. Click for details.`;
+    }
+
+    for (const test of tests) {
+        const resultObj = {
+            id: test.id,
+            value: null
+        };
+        results.results.push(resultObj);
+
+        const li = document.createElement('li');
+        li.id = `test-${test.id.replace(' ', '-')}`;
+        li.innerHTML = `${test.id} - <span class='value'>…</span>`;
+        const valueSpan = li.querySelector('.value');
+
+        testsDetailsDiv.appendChild(li);
+
+        try {
+            const result = test.run();
+
+            if (result instanceof Promise) {
+                result
+                    .then(data => {
+                        valueSpan.innerHTML = resultToHTML(data);
+                        resultObj.value = data || null;
+                    })
+                    .catch(e => {
+                        failed++;
+                        valueSpan.innerHTML = `❌ error thrown ("${e.message ? e.message : e}")`;
+                        updateSummary();
+                    });
+            } else {
+                valueSpan.innerHTML = resultToHTML(data);
+                resultObj.value = result || null;
+            }
+        } catch (e) {
+            failed++;
+            valueSpan.innerHTML = `❌ error thrown ("${e.message ? e.message : e}")`;
+        }
+
+        all++;
+    }
+
+    updateSummary();
+
+    startButton.removeAttribute('disabled');
+}
+
+function downloadTheResults () {
+    const data = JSON.stringify(results, null, 2);
+    const a = document.createElement('a');
+    const url = window.URL.createObjectURL(new Blob([data], { type: 'application/json' }));
+    a.href = url;
+    a.download = 'https-loop-protection-results.json';
+
+    document.body.appendChild(a);
+    a.click();
+
+    window.URL.revokeObjectURL(url);
+    a.remove();
+}
+
+downloadButton.addEventListener('click', () => downloadTheResults());
+
+// run tests if button was clicked or…
+startButton.addEventListener('click', () => runTests());
+
+// if url query is '?run' start tests imadiatelly
+if (document.location.search === '?run') {
+    runTests();
+}

--- a/privacy-protections/https-loop-protection/main.js
+++ b/privacy-protections/https-loop-protection/main.js
@@ -13,7 +13,7 @@ const tests = [
         run: () => {
             let res;
             const promise = new Promise((resolve, reject) => { res = resolve; });
-            const otherWindow = window.open(`http://${TEST_DOMAIN}/privacy-protections/https-loop-protection/http-only.html`);
+            const otherWindow = window.open(`http://${TEST_DOMAIN}/privacy-protections/https-loop-protection/http-only.html?start`);
 
             const interval = setInterval(() => {
                 otherWindow.postMessage({ action: 'url', type: 'navigation' }, `http://${TEST_DOMAIN}/`);

--- a/privacy-protections/https-loop-protection/main.js
+++ b/privacy-protections/https-loop-protection/main.js
@@ -101,7 +101,7 @@ function runTests () {
                         updateSummary();
                     });
             } else {
-                valueSpan.innerHTML = resultToHTML(data);
+                valueSpan.innerHTML = resultToHTML(result);
                 resultObj.value = result || null;
             }
         } catch (e) {

--- a/privacy-protections/https-loop-protection/style.css
+++ b/privacy-protections/https-loop-protection/style.css
@@ -1,0 +1,7 @@
+* {
+    box-sizing: border-box;
+}
+
+.value {
+    color: gray;
+}

--- a/privacy-protections/https-upgrades/main.js
+++ b/privacy-protections/https-upgrades/main.js
@@ -174,7 +174,7 @@ function downloadTheResults () {
     const a = document.createElement('a');
     const url = window.URL.createObjectURL(new Blob([data], { type: 'application/json' }));
     a.href = url;
-    a.download = 'fingerprinting-results.json';
+    a.download = 'https-upgrades-results.json';
 
     document.body.appendChild(a);
     a.click();

--- a/privacy-protections/index.html
+++ b/privacy-protections/index.html
@@ -17,6 +17,7 @@
         <li><a href='./storage-blocking/'>Storage blocking</a></li>
         <li><a href='./referrer-trimming/'>Referrer trimming</a></li>
         <li><a href='./https-upgrades/'>HTTPS upgrades</a></li>
+        <li><a href='./https-loop-protection/'>HTTPS upgrade loop protection</a></li>
         <li><a href='./click-to-load/'>Facebook click to load</a></li>
         <li><a href='./surrogates/'>Surrogates</a></li>
     </ul>


### PR DESCRIPTION
Domain is HTTPS upgradable but page will constantly try to downgrade to HTTP. Client should detect that and allow page to load. Unfortunately our extension seems to have a bug and doesn't do it.

https://app.asana.com/0/1186013049913869/1201057222436407/f