### PR TITLE
Move autoconsent button creation to script

### DIFF
--- a/features/autoconsent/index.html
+++ b/features/autoconsent/index.html
@@ -14,7 +14,6 @@
 
 <p id="privacy-test-page-cmp-test">
   This is a fake consent popup:
-  <button id="reject-all">This should be clicked automatically.</button>
 </p>
 
 <p>Real sites to test on:</p>

--- a/features/autoconsent/main.js
+++ b/features/autoconsent/main.js
@@ -71,7 +71,11 @@ Object.keys(testSites).forEach((cmpName) => {
 });
 
 // dummy CMP
-document.getElementById('reject-all').addEventListener('click', (ev) => {
+const button = document.createElement('button');
+button.innerText = 'This should be clicked automatically.';
+button.id = 'reject-all';
+document.getElementById('privacy-test-page-cmp-test').appendChild(button);
+button.addEventListener('click', (ev) => {
     ev.target.innerText = 'I was clicked!';
     window.results.results.push('button_clicked');
 });


### PR DESCRIPTION
This fixes a race where the button is clicked before the event listener is attached.