### PR TITLE
change from `ddg` to `duckduckgo` on the navigator interface

### DIFF
--- a/features/navigator-interface.html
+++ b/features/navigator-interface.html
@@ -12,13 +12,17 @@
             callAfterDelay(detectInterface);
         }
 
-        function detectInterface () {
-            const hasInterface = 'ddg' in navigator;
-            let isExtension = false;
+        async function detectInterface () {
+            const hasInterface = 'duckduckgo' in navigator;
+            let platform = 'unknown';
+            let isDuckDuckGo = false;
 
             if (hasInterface) {
-                if (typeof navigator.ddg.isExtension === 'function') {
-                    isExtension = navigator.ddg.isExtension();
+                if (typeof navigator.duckduckgo.platform === 'string') {
+                    platform = navigator.duckduckgo.platform;
+                }
+                if (typeof navigator.duckduckgo.isDuckDuckGo === 'function') {
+                    isDuckDuckGo = await navigator.duckduckgo.isDuckDuckGo();
                 }
             }
 
@@ -26,13 +30,14 @@
                 page: 'navigator-interface',
                 date: (new Date()).toUTCString(),
                 results: [
-                    { id: 'namespace', value: hasInterface },
-                    { id: 'extension', value: isExtension }
+                    { id: 'interface', value: hasInterface },
+                    { id: 'isDuckDuckGo', value: isDuckDuckGo },
+                    { id: 'platform', value: platform }
                 ]
             };
 
             for (const result of results.results) {
-                document.getElementById(result.id).textContent = `DDG ${result.id}: ${result.value}`;
+                document.getElementById(result.id).textContent = `${result.id}: ${result.value}`;
             }
 
             window.results = results;
@@ -42,11 +47,11 @@
 <body onload="init()">
 <p><a href="../index.html">[Home]</a></p>
 
-<p>The new DOM API <code>navigator.ddg</code> is used to provide signals about the presence of DDG products</p>
-<p>This test will try to detect <code>navigator.ddg</code> within a second of the page loading</p>
+<p>The new DOM API <code>navigator.duckduckgo</code> is used to provide signals about the presence of DDG products</p>
 
-<p id="namespace"></p>
-<p id="extension"></p>
+<p id="interface"></p>
+<p id="isDuckDuckGo"></p>
+<p id="platform"></p>
 
 </body>
 </html>


### PR DESCRIPTION
Following some feedback from Product [here](https://app.asana.com/0/0/1201508595219526/1201542311746546/f) it was decided to switch to `navigator.duckduckgo` instead of `navigator.ddg` - this PR reflects that.