### PR TITLE
Bugfix for HSTS partitioning test

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Please note that we are not taking external contributions for new test pages, bu
 
 We have couple of test domains, that all resolve to `privacy-test-pages.glitch.me`, which help us simulate various scenarios:
 
+- `www.first-party.site` - an alternative first-party domain used for tests that require first-party resources on other subdomains (e.g., `hsts.first-party.site`)
 - `good.third-party.site` - non-tracking third party, it's not on our blocklist and will not be blocked by our clients
 - `broken.third-party.site` - tracking third party that we can't block (e.g. due to brekage), it's on our blocklist, but it will not be blocked by our clients
 - `bad.third-party.site` - tracking third party that's on our blocklist and our clients will block

--- a/privacy-protections/storage-partitioning/.eslintrc
+++ b/privacy-protections/storage-partitioning/.eslintrc
@@ -1,5 +1,6 @@
 {
     "globals": {
+        "FIRST_PARTY_SITE": "readonly",
         "FIRST_PARTY_HTTP": "readonly",
         "FIRST_PARTY_HTTPS": "readonly",
         "THIRD_PARTY_HTTP": "readonly",

--- a/privacy-protections/storage-partitioning/helpers/common.js
+++ b/privacy-protections/storage-partitioning/helpers/common.js
@@ -1,4 +1,4 @@
-/* exported THIRD_PARTY_HOSTNAME THIRD_PARTY_HTTP THIRD_PARTY_HTTPS FIRST_PARTY_HOSTNAME FIRST_PARTY_HTTP FIRST_PARTY_HTTPS accessStorageInIframe */
+/* exported THIRD_PARTY_HOSTNAME THIRD_PARTY_HTTP THIRD_PARTY_HTTPS FIRST_PARTY_HOSTNAME FIRST_PARTY_SITE FIRST_PARTY_HTTP FIRST_PARTY_HTTPS accessStorageInIframe */
 const isLocalTest = window.location.hostname.endsWith('.example');
 
 const THIRD_PARTY_HOSTNAME = isLocalTest ? 'third-party.example' : 'good.third-party.site';
@@ -6,6 +6,7 @@ const THIRD_PARTY_HTTP = isLocalTest ? `http://${THIRD_PARTY_HOSTNAME}:3000` : `
 const THIRD_PARTY_HTTPS = `https://${THIRD_PARTY_HOSTNAME}`;
 
 const FIRST_PARTY_HOSTNAME = isLocalTest ? 'first-party.example' : 'www.first-party.site';
+const FIRST_PARTY_SITE = isLocalTest ? 'first-party.example' : 'first-party.site'; // eTLD+1
 const FIRST_PARTY_HTTP = isLocalTest ? `http://${FIRST_PARTY_HOSTNAME}:3000` : `http://${THIRD_PARTY_HOSTNAME}`;
 const FIRST_PARTY_HTTPS = `https://${FIRST_PARTY_HOSTNAME}`;
 

--- a/privacy-protections/storage-partitioning/helpers/tests.js
+++ b/privacy-protections/storage-partitioning/helpers/tests.js
@@ -5,7 +5,7 @@
  */
 
 /* exported testAPIs */
-/* globals FIRST_PARTY_HOSTNAME DB */
+/* globals FIRST_PARTY_SITE DB */
 
 const timeout = 1000; // ms; used for cross-tab communication APIs
 
@@ -573,17 +573,17 @@ const testAPIs = {
         type: 'hsts',
         store: async () => {
             // Clear any current HSTS
-            const clearURL = new URL('/partitioning/clear_hsts.png', `https://hsts.${FIRST_PARTY_HOSTNAME}/`);
+            const clearURL = new URL('/partitioning/clear_hsts.png', `https://hsts.${FIRST_PARTY_SITE}/`);
             await loadSubresource('img', clearURL.href);
 
             // Set HSTS
-            const setURL = new URL('/partitioning/set_hsts.png', `https://hsts.${FIRST_PARTY_HOSTNAME}/`);
+            const setURL = new URL('/partitioning/set_hsts.png', `https://hsts.${FIRST_PARTY_SITE}/`);
             await loadSubresource('img', setURL.href);
         },
         retrieve: async () => {
             // Attempt to retrieve an image over HTTP
             // The retrieval will fail if not upgraded to HTTPS by the browser.
-            const getURL = new URL('/partitioning/get_hsts.png', `http://hsts.${FIRST_PARTY_HOSTNAME}/`);
+            const getURL = new URL('/partitioning/get_hsts.png', `http://hsts.${FIRST_PARTY_SITE}/`);
             const event = await loadSubresource('img', getURL.href);
             if (event.type === 'load') {
                 return 'https';


### PR DESCRIPTION
The HSTS test fails on the live site since the top-level hostname for the live site has a subdomain.