### PR TITLE
Bugfix: HSTS Test

### DIFF
--- a/privacy-protections/storage-partitioning/helpers/common.js
+++ b/privacy-protections/storage-partitioning/helpers/common.js
@@ -1,4 +1,4 @@
-/* exported THIRD_PARTY_HTTP THIRD_PARTY_HTTPS FIRST_PARTY_SITE FIRST_PARTY_HTTP FIRST_PARTY_HTTPS accessStorageInIframe */
+/* exported THIRD_PARTY_HTTP THIRD_PARTY_HTTPS HSTS_FIRST_PARTY FIRST_PARTY_HTTP FIRST_PARTY_HTTPS accessStorageInIframe */
 const isLocalTest = window.location.hostname.endsWith('.example');
 
 const THIRD_PARTY_HOSTNAME = isLocalTest ? 'third-party.example' : 'good.third-party.site';
@@ -6,7 +6,7 @@ const THIRD_PARTY_HTTP = isLocalTest ? `http://${THIRD_PARTY_HOSTNAME}:3000` : `
 const THIRD_PARTY_HTTPS = `https://${THIRD_PARTY_HOSTNAME}`;
 
 const FIRST_PARTY_HOSTNAME = isLocalTest ? 'first-party.example' : 'www.first-party.site';
-const FIRST_PARTY_SITE = isLocalTest ? 'first-party.example' : 'first-party.site'; // eTLD+1
+const HSTS_FIRST_PARTY = isLocalTest ? 'hsts.first-party.example' : 'privacy-test-pages.glitch.me';
 const FIRST_PARTY_HTTP = isLocalTest ? `http://${FIRST_PARTY_HOSTNAME}:3000` : `http://${THIRD_PARTY_HOSTNAME}`;
 const FIRST_PARTY_HTTPS = `https://${FIRST_PARTY_HOSTNAME}`;
 

--- a/privacy-protections/storage-partitioning/helpers/common.js
+++ b/privacy-protections/storage-partitioning/helpers/common.js
@@ -1,4 +1,4 @@
-/* exported THIRD_PARTY_HTTP THIRD_PARTY_HTTPS HSTS_FIRST_PARTY FIRST_PARTY_HTTP FIRST_PARTY_HTTPS accessStorageInIframe */
+/* exported THIRD_PARTY_HTTP THIRD_PARTY_HTTPS HSTS_HOSTNAME FIRST_PARTY_HTTP FIRST_PARTY_HTTPS accessStorageInIframe */
 const isLocalTest = window.location.hostname.endsWith('.example');
 
 const THIRD_PARTY_HOSTNAME = isLocalTest ? 'third-party.example' : 'good.third-party.site';
@@ -6,9 +6,10 @@ const THIRD_PARTY_HTTP = isLocalTest ? `http://${THIRD_PARTY_HOSTNAME}:3000` : `
 const THIRD_PARTY_HTTPS = `https://${THIRD_PARTY_HOSTNAME}`;
 
 const FIRST_PARTY_HOSTNAME = isLocalTest ? 'first-party.example' : 'www.first-party.site';
-const HSTS_FIRST_PARTY = isLocalTest ? 'hsts.first-party.example' : 'privacy-test-pages.glitch.me';
 const FIRST_PARTY_HTTP = isLocalTest ? `http://${FIRST_PARTY_HOSTNAME}:3000` : `http://${THIRD_PARTY_HOSTNAME}`;
 const FIRST_PARTY_HTTPS = `https://${FIRST_PARTY_HOSTNAME}`;
+
+const HSTS_HOSTNAME = isLocalTest ? 'hsts.first-party.example' : 'privacy-test-pages.glitch.me';
 
 // Inject an iframe to retrieve values from test APIs
 function accessStorageInIframe (frameOrigin, sessionId, mode, apiTypes = [], frameId) {

--- a/privacy-protections/storage-partitioning/helpers/tests.js
+++ b/privacy-protections/storage-partitioning/helpers/tests.js
@@ -5,7 +5,7 @@
  */
 
 /* exported testAPIs */
-/* globals HSTS_FIRST_PARTY DB */
+/* globals HSTS_HOSTNAME DB */
 
 const timeout = 1000; // ms; used for cross-tab communication APIs
 
@@ -573,17 +573,17 @@ const testAPIs = {
         type: 'hsts',
         store: async () => {
             // Clear any current HSTS
-            const clearURL = new URL('/partitioning/clear_hsts.png', `https://${HSTS_FIRST_PARTY}/`);
+            const clearURL = new URL('/partitioning/clear_hsts.png', `https://${HSTS_HOSTNAME}/`);
             await loadSubresource('img', clearURL.href);
 
             // Set HSTS
-            const setURL = new URL('/partitioning/set_hsts.png', `https://${HSTS_FIRST_PARTY}/`);
+            const setURL = new URL('/partitioning/set_hsts.png', `https://${HSTS_HOSTNAME}/`);
             await loadSubresource('img', setURL.href);
         },
         retrieve: async () => {
             // Attempt to retrieve an image over HTTP
             // The retrieval will fail if not upgraded to HTTPS by the browser.
-            const getURL = new URL('/partitioning/get_hsts.png', `http://${HSTS_FIRST_PARTY}/`);
+            const getURL = new URL('/partitioning/get_hsts.png', `http://${HSTS_HOSTNAME}/`);
             const event = await loadSubresource('img', getURL.href);
             if (event.type === 'load') {
                 return 'https';

--- a/privacy-protections/storage-partitioning/helpers/tests.js
+++ b/privacy-protections/storage-partitioning/helpers/tests.js
@@ -5,7 +5,7 @@
  */
 
 /* exported testAPIs */
-/* globals FIRST_PARTY_SITE DB */
+/* globals HSTS_FIRST_PARTY DB */
 
 const timeout = 1000; // ms; used for cross-tab communication APIs
 
@@ -573,17 +573,17 @@ const testAPIs = {
         type: 'hsts',
         store: async () => {
             // Clear any current HSTS
-            const clearURL = new URL('/partitioning/clear_hsts.png', `https://hsts.${FIRST_PARTY_SITE}/`);
+            const clearURL = new URL('/partitioning/clear_hsts.png', `https://${HSTS_FIRST_PARTY}/`);
             await loadSubresource('img', clearURL.href);
 
             // Set HSTS
-            const setURL = new URL('/partitioning/set_hsts.png', `https://hsts.${FIRST_PARTY_SITE}/`);
+            const setURL = new URL('/partitioning/set_hsts.png', `https://${HSTS_FIRST_PARTY}/`);
             await loadSubresource('img', setURL.href);
         },
         retrieve: async () => {
             // Attempt to retrieve an image over HTTP
             // The retrieval will fail if not upgraded to HTTPS by the browser.
-            const getURL = new URL('/partitioning/get_hsts.png', `http://hsts.${FIRST_PARTY_SITE}/`);
+            const getURL = new URL('/partitioning/get_hsts.png', `http://${HSTS_FIRST_PARTY}/`);
             const event = await loadSubresource('img', getURL.href);
             if (event.type === 'load') {
                 return 'https';

--- a/privacy-protections/storage-partitioning/server/routes.js
+++ b/privacy-protections/storage-partitioning/server/routes.js
@@ -92,6 +92,8 @@ router.get('/get_hsts.png', (req, res) => {
     let isHTTPS = req.protocol === 'https';
     // The X-Forwarded-Proto header is added by Glitch's proxy
     // and reveals the original protocol used during the connection
+    // This header will always show HTTPS for all custom domains,
+    // it's only correct for privacy-test-pages.glitch.me.
     if (req.headers['x-forwarded-proto']) {
         isHTTPS = req.headers['x-forwarded-proto'].split(',', 1)[0] === 'https';
     }


### PR DESCRIPTION
This is a second bugfix for the HSTS test on the live site. I've actually verified this one manually this time, so hopefully it will be the last.

It seems we can't do the HSTS check on custom domains because Glitch doesn't provide a way to discover the original protocol for those domains. The header we're relying on to disclose the protocol of the client connection only works for the glitch domain.