### PR TITLE
add a page for testing autofill for login forms embedded in an iframe

### DIFF
--- a/autofill/frame-form-submission-child.html
+++ b/autofill/frame-form-submission-child.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Form submission detection and autofill within an iframe</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+
+<body>
+  <p id="demo"></p>
+
+  <div class="">
+    <p>Submitting this form should prompt to save credentials.</p>
+
+    <form id="click-form" novalidate action="/autofill/form-submission.html">
+      <h3>Sign in form with click handler</h3>
+      <fieldset>
+        <label for="email">Email</label>
+        <input id="email" type="email">
+        <label for="password">Password</label>
+        <input id="password" type="password">
+        <button type="submit">Sign in</button>
+      </fieldset>
+    </form>
+    <script>
+      const clickForm = document.getElementById('click-form');
+      const clickFormButton = clickForm.querySelector('button');
+      clickFormButton?.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          // Note that form.submit() does not fire a submit event
+          clickForm.submit();
+      }, true);
+    </script>
+  </div>
+
+</body>
+
+</html>

--- a/autofill/frame-form-submission-child.html
+++ b/autofill/frame-form-submission-child.html
@@ -30,8 +30,7 @@
       clickFormButton?.addEventListener('click', (e) => {
           e.preventDefault();
           e.stopImmediatePropagation();
-          // Note that form.submit() does not fire a submit event
-          clickForm.submit();
+          clickForm.innerHTML = '<h1>Done!</h1>';
       }, true);
     </script>
   </div>

--- a/autofill/frame-form-submission-parent.html
+++ b/autofill/frame-form-submission-parent.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Form submission detection and autofill within iframe</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+
+<body>
+  <p><a href="../index.html">[Home]</a></p>
+
+  <p>We should show the autofill prompts for these iframed forms (note: it does <em>not</em> work on Android)</p>
+
+  <h2>Same origin iframe</h2>
+  <iframe src="./frame-form-submission-child.html" id="frame-form"></iframe>
+  
+  <h2>Cross origin iframe</h2>
+  <iframe src="https://good.third-party.site/autofill/frame-form-submission-child.html" id="frame-form-cross-origin"></iframe>
+
+  <style>
+    iframe {
+      height: 20em;
+      display:inline-block;
+    }
+  </style>
+</body>

--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
 	<li><a href="./autofill/frame-parent.html">Email autofill when form is within an iframe</a></li>
 	<li><a href="./autofill/modal.html">Email autofill form within self-closing modal</a></li>
 	<li><a href="./autofill/form-submission.html">Form submission detection and autofill</a></li>
+	<li><a href="./autofill/frame-form-submission-parent.html">Form submission detection and autofill within an iframe</a></li>
 </ul>
 
 <h2>Other</h2>


### PR DESCRIPTION
Asana: https://app.asana.com/0/72649045549333/1201816478631739/f

Add a new page for testing autofill for logins within an iframe. There are related pages ([parent](https://github.com/duckduckgo/privacy-test-pages/blob/main/autofill/frame-parent.html), [child](https://github.com/duckduckgo/privacy-test-pages/blob/main/autofill/frame-child.html)) to test autofill with iframes, but they target the autofill email integration and not logins. Felt like adding a new page makes more sense instead of extending the already existing one to avoid breaking tests or whatnot.