### PR TITLE
Ad attribution tests without ad_domain provided should now fail

### DIFF
--- a/adClickFlow/shared/testCases.json
+++ b/adClickFlow/shared/testCases.json
@@ -23,11 +23,11 @@
           "requests": [
             {
               "url": "https://convert.ad-company.site/convert.js?ad=1",
-              "status": "loaded"
+              "status": "blocked"
             },
             {
               "url": "https://convert.ad-company.site/ping.gif",
-              "status": "loaded"
+              "status": "parent blocked"
             },
             {
               "url": "https://www.ad-company.site/track.js?ad=1",
@@ -67,11 +67,11 @@
           "requests": [
             {
               "url": "https://convert.ad-company.site/convert.js?ad=1",
-              "status": "loaded"
+              "status": "blocked"
             },
             {
               "url": "https://convert.ad-company.site/ping.gif",
-              "status": "loaded"
+              "status": "parent blocked"
             },
             {
               "url": "https://www.ad-company.site/track.js?ad=1",
@@ -361,10 +361,10 @@
         }
       },
       {
-        "name": "Click on [Ad 1]",
+        "name": "Click on [Ad 5]",
         "action": {
           "type": "click-new-tab",
-          "id": "ad-id-1"
+          "id": "ad-id-5"
         },
         "expected": {
           "newTab": true,
@@ -433,10 +433,10 @@
         }
       },
       {
-        "name": "Click on [Ad 1]",
+        "name": "Click on [Ad 5]",
         "action": {
           "type": "click",
-          "id": "ad-id-1"
+          "id": "ad-id-5"
         },
         "expected": {
           "url": "https://www.publisher-company.site/product.html?p=12",


### PR DESCRIPTION
Since merging: https://github.com/duckduckgo/privacy-configuration/pull/345 this now fails in the extension as we don't support links without ad_domain anymore.

I switched out ad-1 for ad-5 which is supported on https://www.search-company.site/ as it provides the correct parameter.