### PR TITLE
Expand tracker blocking test (redirect and iframe^2)

### DIFF
--- a/privacy-protections/request-blocking/frame.html
+++ b/privacy-protections/request-blocking/frame.html
@@ -18,7 +18,7 @@
                     })
                     .catch(e => {
                         window.parent.postMessage('frame fetch failed', '*');
-                    })
+                    });
             }
         };
 

--- a/privacy-protections/request-blocking/middleframe.html
+++ b/privacy-protections/request-blocking/middleframe.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Middleframe Test</title>
+</head>
+<body>
+    <script>
+        const iframe = document.createElement('iframe');
+        iframe.src = `./frame.html?${Math.random()}`;
+
+        const onMessage = msg => {
+            if (msg.data.action && msg.data.action === 'fetch') {
+                iframe.addEventListener('load', () => {
+                    // pass message from upper frame to lower frame
+                    iframe.contentWindow.postMessage({ action: 'fetch', url: msg.data.url });
+                });
+                document.body.appendChild(iframe);
+            } else if (msg.data && (msg.data.includes('frame fetch loaded') || msg.data.includes('frame fetch failed'))) {
+                // pass message from lower frame to upper frame
+                window.parent.postMessage(msg.data, '*');
+                window.removeEventListener('message', onMessage);
+            }
+        };
+
+        window.addEventListener('message', onMessage);
+    </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -231,6 +231,22 @@ app.get('/come-back', (req, res) => {
 </html>`);
 });
 
+const REDIRECT_ALLOWLIST = ['bad.third-party.site'];
+
+app.get('/redirect', (req, res) => {
+    const destination = req.query.destination;
+
+    if (!REDIRECT_ALLOWLIST.find(allowHost => destination.startsWith('https://' + allowHost + '/'))) {
+        res.statusCode = 403;
+        res.end();
+        return;
+    }
+
+    res.set('Location', destination);
+    res.statusCode = 307;
+    res.end();
+});
+
 const blockingRoutes = require('./privacy-protections/request-blocking/server/routes');
 app.use('/block-me', blockingRoutes);
 


### PR DESCRIPTION
Adds two test for edge-cases that we encountered over the last few months:
- tracker loaded via a safe redirect (-> good 307 -> bad)
- tracker loaded from an iframe within an iframe