### PR TITLE
Run cookie header tests in frames.

### DIFF
--- a/privacy-protections/storage-blocking/helpers/commonTests.js
+++ b/privacy-protections/storage-blocking/helpers/commonTests.js
@@ -1,53 +1,35 @@
 /* exported commonTests */
 /* global cookieStore, THIRD_PARTY_TRACKER_ORIGIN, THIRD_PARTY_ORIGIN */
 
+function generateCookieHeaderTest (namePrefix, origin) {
+    return {
+        id: `${namePrefix} header cookie`,
+        store: (data) => {
+            return fetch(`${origin}/set-cookie?value=${data}`, { credentials: 'include' }).then(r => {
+                if (!r.ok) {
+                    throw new Error('Request failed.');
+                }
+            });
+        },
+        retrive: () => {
+            return fetch(`${origin}/reflect-headers`, { credentials: 'include' })
+                .then(r => r.json())
+                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
+        }
+    };
+}
+
+const cookieHeaderTests = [generateCookieHeaderTest('first party', '')];
+if (document.location.origin !== THIRD_PARTY_ORIGIN) {
+    cookieHeaderTests.push(generateCookieHeaderTest('safe third party', THIRD_PARTY_ORIGIN));
+}
+if (document.location.origin !== THIRD_PARTY_TRACKER_ORIGIN) {
+    cookieHeaderTests.push(generateCookieHeaderTest('tracking third party', THIRD_PARTY_TRACKER_ORIGIN));
+}
+
 // tests that are common for both main frame and an iframe
 const commonTests = [
-    {
-        id: 'first party header cookie',
-        store: (data) => {
-            return fetch(`/set-cookie?value=${data}`).then(r => {
-                if (!r.ok) {
-                    throw new Error('Request failed.');
-                }
-            });
-        },
-        retrive: () => {
-            return fetch('/reflect-headers')
-                .then(r => r.json())
-                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
-        }
-    },
-    {
-        id: 'safe third party header cookie',
-        store: (data) => {
-            return fetch(`${THIRD_PARTY_ORIGIN}/set-cookie?value=${data}`, { credentials: 'include' }).then(r => {
-                if (!r.ok) {
-                    throw new Error('Request failed.');
-                }
-            });
-        },
-        retrive: () => {
-            return fetch(`${THIRD_PARTY_ORIGIN}/reflect-headers`, { credentials: 'include' })
-                .then(r => r.json())
-                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
-        }
-    },
-    {
-        id: 'tracking third party header cookie',
-        store: (data) => {
-            return fetch(`${THIRD_PARTY_TRACKER_ORIGIN}/set-cookie?value=${data}`, { credentials: 'include' }).then(r => {
-                if (!r.ok) {
-                    throw new Error('Request failed.');
-                }
-            });
-        },
-        retrive: () => {
-            return fetch(`${THIRD_PARTY_TRACKER_ORIGIN}/reflect-headers`, { credentials: 'include' })
-                .then(r => r.json())
-                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
-        }
-    },
+    ...cookieHeaderTests,
     {
         id: 'JS cookie',
         store: (data) => {

--- a/privacy-protections/storage-blocking/helpers/commonTests.js
+++ b/privacy-protections/storage-blocking/helpers/commonTests.js
@@ -1,7 +1,53 @@
 /* exported commonTests */
-/* global cookieStore */
+/* global cookieStore, THIRD_PARTY_TRACKER_ORIGIN, THIRD_PARTY_ORIGIN */
+
 // tests that are common for both main frame and an iframe
 const commonTests = [
+    {
+        id: 'first party header cookie',
+        store: (data) => {
+            return fetch(`/set-cookie?value=${data}`).then(r => {
+                if (!r.ok) {
+                    throw new Error('Request failed.');
+                }
+            });
+        },
+        retrive: () => {
+            return fetch('/reflect-headers')
+                .then(r => r.json())
+                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
+        }
+    },
+    {
+        id: 'safe third party header cookie',
+        store: (data) => {
+            return fetch(`${THIRD_PARTY_ORIGIN}/set-cookie?value=${data}`, { credentials: 'include' }).then(r => {
+                if (!r.ok) {
+                    throw new Error('Request failed.');
+                }
+            });
+        },
+        retrive: () => {
+            return fetch(`${THIRD_PARTY_ORIGIN}/reflect-headers`, { credentials: 'include' })
+                .then(r => r.json())
+                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
+        }
+    },
+    {
+        id: 'tracking third party header cookie',
+        store: (data) => {
+            return fetch(`${THIRD_PARTY_TRACKER_ORIGIN}/set-cookie?value=${data}`, { credentials: 'include' }).then(r => {
+                if (!r.ok) {
+                    throw new Error('Request failed.');
+                }
+            });
+        },
+        retrive: () => {
+            return fetch(`${THIRD_PARTY_TRACKER_ORIGIN}/reflect-headers`, { credentials: 'include' })
+                .then(r => r.json())
+                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
+        }
+    },
     {
         id: 'JS cookie',
         store: (data) => {

--- a/privacy-protections/storage-blocking/helpers/globals.js
+++ b/privacy-protections/storage-blocking/helpers/globals.js
@@ -1,0 +1,3 @@
+/* exported THIRD_PARTY_ORIGIN,THIRD_PARTY_TRACKER_ORIGIN */
+const THIRD_PARTY_ORIGIN = 'https://good.third-party.site';
+const THIRD_PARTY_TRACKER_ORIGIN = 'https://broken.third-party.site';

--- a/privacy-protections/storage-blocking/iframe.html
+++ b/privacy-protections/storage-blocking/iframe.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Storage blocking test page - iframe</title>
     <script src='/helpers/idb-wrapper.js'></script>
+    <script src="./helpers/globals.js"></script>
     <script src='./helpers/commonTests.js'></script>
     <script src='./iframe.js'></script>
 </head>

--- a/privacy-protections/storage-blocking/index.html
+++ b/privacy-protections/storage-blocking/index.html
@@ -6,6 +6,7 @@
     <title>Storage blocking test page</title>
 
     <script src='/helpers/idb-wrapper.js' defer></script>
+    <script src="./helpers/globals.js"></script>
     <script src='./helpers/commonTests.js'></script>
     <script src='https://broken.third-party.site/privacy-protections/storage-blocking/3rdparty.js' defer></script>
     <script src='https://good.third-party.site/privacy-protections/storage-blocking/3rdparty.js' defer></script>

--- a/privacy-protections/storage-blocking/main.js
+++ b/privacy-protections/storage-blocking/main.js
@@ -1,6 +1,4 @@
-/* globals commonTests */
-const THIRD_PARTY_ORIGIN = 'https://good.third-party.site';
-const THIRD_PARTY_TRACKER_ORIGIN = 'https://broken.third-party.site';
+/* globals commonTests,THIRD_PARTY_ORIGIN,THIRD_PARTY_TRACKER_ORIGIN */
 
 const storeButton = document.querySelector('#store');
 const retriveButton = document.querySelector('#retrive');
@@ -82,51 +80,6 @@ function create3pIframeTest (name, origin) {
 }
 
 const tests = [
-    {
-        id: 'first party header cookie',
-        store: (data) => {
-            return fetch(`/set-cookie?value=${data}`).then(r => {
-                if (!r.ok) {
-                    throw new Error('Request failed.');
-                }
-            });
-        },
-        retrive: () => {
-            return fetch('/reflect-headers')
-                .then(r => r.json())
-                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
-        }
-    },
-    {
-        id: 'safe third party header cookie',
-        store: (data) => {
-            return fetch(`${THIRD_PARTY_ORIGIN}/set-cookie?value=${data}`, { credentials: 'include' }).then(r => {
-                if (!r.ok) {
-                    throw new Error('Request failed.');
-                }
-            });
-        },
-        retrive: () => {
-            return fetch(`${THIRD_PARTY_ORIGIN}/reflect-headers`, { credentials: 'include' })
-                .then(r => r.json())
-                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
-        }
-    },
-    {
-        id: 'tracking third party header cookie',
-        store: (data) => {
-            return fetch(`${THIRD_PARTY_TRACKER_ORIGIN}/set-cookie?value=${data}`, { credentials: 'include' }).then(r => {
-                if (!r.ok) {
-                    throw new Error('Request failed.');
-                }
-            });
-        },
-        retrive: () => {
-            return fetch(`${THIRD_PARTY_TRACKER_ORIGIN}/reflect-headers`, { credentials: 'include' })
-                .then(r => r.json())
-                .then(data => data.headers.cookie.match(/headerdata=([0-9]+)/)[1]);
-        }
-    },
     create3pIframeTest('safe', THIRD_PARTY_ORIGIN),
     create3pIframeTest('tracking', THIRD_PARTY_TRACKER_ORIGIN),
     {
@@ -278,7 +231,7 @@ function retrieveData () {
         });
     }
 
-    tests.concat(commonTests).forEach(test => {
+    [...commonTests, ...tests].forEach(test => {
         all++;
 
         const li = document.createElement('li');

--- a/server.js
+++ b/server.js
@@ -200,7 +200,11 @@ app.get('/set-cookie', (req, res) => {
     if (!req.query.value) {
         return res.sendStatus(401);
     }
-    return res.cookie('headerdata', req.query.value, { expires, httpOnly: true, sameSite: 'none', secure: true }).sendStatus(200);
+    let cookieName = 'headerdata';
+    if (req.query.name) {
+        cookieName = req.query.name;
+    }
+    return res.cookie(cookieName, req.query.value, { expires, httpOnly: true, sameSite: 'none', secure: true }).sendStatus(200);
 });
 
 // returns a random number and sets caching for a year


### PR DESCRIPTION
Moves the storage header cookie sites to the list of common tests, so that they also run in safe and tracker iframes.