### PR TITLE
Improve the AMP link protection test page

### DIFF
--- a/privacy-protections/amp/index.html
+++ b/privacy-protections/amp/index.html
@@ -16,29 +16,30 @@
 </head>
 <body>
   <p><a href="../../">[Home]</a> ↣ <a href="../">[Privacy Protections Tests]</a> ↣ <strong>[AMP Links]</strong></p>
-  
+
   <p>This test page has sample links to use for AMP link protection. When clicking on the sample links you should be taken to the listed "Expected" page.</P>
 
   <div id="demo">
     <p>google.com AMP Links</p>
     <ul>
       <li>
-        <p><a id="link1" href="https://www.google.com/amp/s/www.vox.com/platform/amp/identities/22530103/asians-americans-wealth-income-gap-crazy-rich-model-minority">Simple link</a></p>
+        <p><a id="link1" href="https://www.google.com/amp/s/www.vox.com/platform/amp/identities/22530103/asians-americans-wealth-income-gap-crazy-rich-model-minority">*Simple link</a></p>
         <p class="expected">Expected: https://www.vox.com/platform/amp/identities/22530103/asians-americans-wealth-income-gap-crazy-rich-model-minority</p>
       </li>
       <li>
-        <p><a href="https://www.google.com/amp/s/www.nytimes.com/2021/09/20/business/jeff-bezos-earth-fund.amp.html">Simple link #2</a></p>
+        <p><a href="https://www.google.com/amp/s/www.nytimes.com/2021/09/20/business/jeff-bezos-earth-fund.amp.html">*Simple link #2</a></p>
         <p class="expected">Expected: https://www.nytimes.com/2021/09/20/business/jeff-bezos-earth-fund.html</p>
       </li>
       <li>
-        <p><a href="https://www.google.fr/amp/s/www.brookings.edu/research/reforming-global-fossil-fuel-subsidies-how-the-united-states-can-restart-international-cooperation/?amp">Non Standard TLD (Google Domain)</a></p>
-        <p class="expected">Expected: https://www.brookings.edu/research/reforming-global-fossil-fuel-subsidies-how-the-united-states-can-restart-international-cooperation</p>
+        <p><a href="https://www.google.fr/amp/s/www.brookings.edu/research/reforming-global-fossil-fuel-subsidies-how-the-united-states-can-restart-international-cooperation/?amp">*Non Standard TLD (Google Domain)</a></p>
+        <p class="expected">Expected: https://www.brookings.edu/research/reforming-global-fossil-fuel-subsidies-how-the-united-states-can-restart-international-cooperation/?amp</p>
       </li>
       <li>
-        <p><a href="https://www-wpxi-com.cdn.ampproject.org/v/s/www.wpxi.com/news/top-stories/pihl-bans-armstrong-student-section-hockey-games-after-vulgar-chants-directed-female-goalie/G2RP5FZA3ZDYRLFSWGDGQH2MY4/?amp_js_v=a6&amp_gsa=1&outputType=amp&usqp=mq331AQKKAFQArABIIACAw%3D%3D&fbclid=IwAR1TYTsjFEPy42VACpBR0n2jP-6whynOxwVqxpDMTWIRgW2vFlj573xVkEI#aoh=16358554203777&referrer=https%3A%2F%2Fwww.google.com&amp_tf=From%20%251%24s&ampshare=https%3A%2F%2Fwww.wpxi.com%2Fnews%2Ftop-stories%2Fpihl-bans-armstrong-student-section-hockey-games-after-vulgar-chants-directed-female-goalie%2FG2RP5FZA3ZDYRLFSWGDGQH2MY4%2F">ampproject.org with parameters</a></p>
-        <p class="expected">Expected: https://www.wpxi.com/news/top-stories/pihl-bans-armstrong-student-section-hockey-games-after-vulgar-chants-directed-female-goalie/G2RP5FZA3ZDYRLFSWGDGQH2MY4/?amp_js_v=a6&_gsa=1&outputType=amp&usqp=mq331AQKKAFQArABIIACAw%3D%3D&fbclid=IwAR1TYTsjFEPy42VACpBR0n2jP-6whynOxwVqxpDMTWIRgW2vFlj573xVkEI#aoh=16358554203777&referrer=https%3A%2F%2Fwww.google.com&_tf=From%20%251%24s&ampshare=https%3A%2F%2Fwww.wpxi.com%2Fnews%2Ftop-stories%2Fpihl-bans-armstrong-student-section-hockey-games-after-vulgar-chants-directed-female-goalie%2FG2RP5FZA3ZDYRLFSWGDGQH2MY4%2F</p>
+        <p><a href="https://www-wpxi-com.cdn.ampproject.org/v/s/www.wpxi.com/news/top-stories/pihl-bans-armstrong-student-section-hockey-games-after-vulgar-chants-directed-female-goalie/G2RP5FZA3ZDYRLFSWGDGQH2MY4/?amp_js_v=a6&_gsa=1&outputType=amp&usqp=mq331AQKKAFQArABIIACAw%3D%3D&referrer=https%3A%2F%2Fwww.google.com&_tf=From%20%251%24s&ampshare=https%3A%2F%2Fwww.wpxi.com%2Fnews%2Ftop-stories%2Fpihl-bans-armstrong-student-section-hockey-games-after-vulgar-chants-directed-female-goalie%2FG2RP5FZA3ZDYRLFSWGDGQH2MY4%2F">ampproject.org with parameters</a></p>
+        <p class="expected">Expected: https://www.wpxi.com/news/top-stories/pihl-bans-armstrong-student-section-hockey-games-after-vulgar-chants-directed-female-goalie/G2RP5FZA3ZDYRLFSWGDGQH2MY4/?amp_js_v=a6&amp;_gsa=1&amp;outputType=amp&amp;usqp=mq331AQKKAFQArABIIACAw%3D%3D&amp;referrer=https%3A%2F%2Fwww.google.com&amp;_tf=From%20%251%24s&amp;ampshare=https%3A%2F%2Fwww.wpxi.com%2Fnews%2Ftop-stories%2Fpihl-bans-armstrong-student-section-hockey-games-after-vulgar-chants-directed-female-goalie%2FG2RP5FZA3ZDYRLFSWGDGQH2MY4%2F</p>
       </li>
     </ul>
+    <i>* - website redirects to non-AMP URL on desktop, even without our protections enabled.</i>
 
     <p>First Party Cloaked AMP links</p>
     <ul>
@@ -71,10 +72,10 @@
         <p class="expected">Expected: https://daily.bandcamp.com/album-of-the-day/pan-daijing-tissues-review</p>
       </li>
       <li>
-        <p><a href="https://amp.dev/about/websites/">amp.dev</a></p>
-        <p class="expected">Expected: https://amp.dev/about/websites/</p>
+        <p><a href="https://amp.dev/about/websites">amp.dev</a></p>
+        <p class="expected">Expected: https://amp.dev/about/websites</p>
       </li>
     </ul>
-  </div>  
+  </div>
 </body>
 </html>


### PR DESCRIPTION
- Some expected URLs were wrong (e.g. missing trailing /), let's correct
  those.
- Replace ampersands in expected URLs with the proper character
  entity, so that they are handled correctly.
- Simplify the ampproject.org example so that it doesn't contain
  parameters which will be stripped by tracking parameter protection and
  so that it doesn't contain a fragment part in the middle of the
  query parameters (which is invalid).
- Add a note that some of the test cases will be redirected
  successfully on desktop, even without AMP protection enabled.
