### PR TITLE
AdClick tests to validate non-302 redirects

### DIFF
--- a/adClickFlow/server/routes.js
+++ b/adClickFlow/server/routes.js
@@ -3,8 +3,8 @@ async function routeInit () {
     const routes = express.Router();
 
     const { getPubUrl, getPubCompleteUrl } = await import('../shared/utils.mjs');
-    
-    function getRedirectStatusCode(req) {
+
+    function getRedirectStatusCode (req) {
         const codeFromUri = parseInt(req.query.customRedirect);
         return isNaN(codeFromUri) ? 302 : codeFromUri;
     }

--- a/adClickFlow/server/routes.js
+++ b/adClickFlow/server/routes.js
@@ -3,22 +3,28 @@ async function routeInit () {
     const routes = express.Router();
 
     const { getPubUrl, getPubCompleteUrl } = await import('../shared/utils.mjs');
+    
+    function getRedirectStatusCode(req) {
+        const codeFromUri = parseInt(req.query.customRedirect);
+        return isNaN(codeFromUri) ? 302 : codeFromUri;
+    }
+
     routes.get('/ad/aclick', (req, res) => {
         const adPath = getPubUrl(req.query.ID, req.hostname);
-        res.redirect(302, adPath);
+        res.redirect(getRedirectStatusCode(req), adPath);
     });
 
     routes.get('/serp/y.js', (req, res) => {
-        res.redirect(302, decodeURIComponent(req.query.u));
+        res.redirect(getRedirectStatusCode(req), decodeURIComponent(req.query.u));
     });
 
     routes.get('/serp/m.js', (req, res) => {
-        res.redirect(302, decodeURIComponent(req.query.u));
+        res.redirect(getRedirectStatusCode(req), decodeURIComponent(req.query.u));
     });
 
     function redirectToPubComplete (req, res) {
         const pubCompleteUrl = getPubCompleteUrl(req.hostname);
-        res.redirect(302, pubCompleteUrl);
+        res.redirect(getRedirectStatusCode(req), pubCompleteUrl);
     }
 
     routes.post('/pay/process.html', redirectToPubComplete);

--- a/adClickFlow/shared/utils.mjs
+++ b/adClickFlow/shared/utils.mjs
@@ -165,14 +165,14 @@ const ads = {
         product: 200,
         useMPath: true,
         differentSubdomainAdDomain: true
-    },    
+    },
     15: {
         title: '[Ad 15] SERP Ad (heuristic) with 307 redirect',
         summary: '/y.js; 307 redirect status code, Empty ad_domain parameter; No u3 param',
         product: 12,
         emptyAdDomain: true,
         customRedirect: 307
-    },     
+    },
     16: {
         title: '[Ad 16] SERP Ad (heuristic) with 301 redirect',
         summary: '/y.js; 301 redirect status code, Empty ad_domain parameter; No u3 param',

--- a/adClickFlow/shared/utils.mjs
+++ b/adClickFlow/shared/utils.mjs
@@ -20,11 +20,16 @@ function getAdUrl (id, hostname) {
     const adPath = `https://www.${adHostname}/aclick`;
     const adUrl = new URL(adPath);
     const params = ['ld', 'u', 'rlid', 'vqd', 'iurl', 'CID'];
+    const customRedirect = 'customRedirect' in ads[id];
     // add some fake values
     for (const param of params) {
         adUrl.searchParams.append(param, `${param}Value`);
     }
     adUrl.searchParams.append('ID', id)
+
+    if (customRedirect) {
+        adUrl.searchParams.append('customRedirect', ads[id]['customRedirect']);
+    }
 
     // Build Search Redirection URL
     const useMPath = 'useMPath' in ads[id];
@@ -61,6 +66,11 @@ function getAdUrl (id, hostname) {
     } else if (includeParam) {
         searchUrl.searchParams.append('u3', 'foo');
     }
+
+    if (customRedirect) {
+        searchUrl.searchParams.append('customRedirect', ads[id]['customRedirect']);
+    }
+
     // normal URLs use a different param, but we use 'u' here to avoid conflict with other params.
     searchUrl.searchParams.append('u', encodeURIComponent(adUrl));
     return searchUrl.href;
@@ -155,6 +165,20 @@ const ads = {
         product: 200,
         useMPath: true,
         differentSubdomainAdDomain: true
+    },    
+    15: {
+        title: '[Ad 15] SERP Ad (heuristic) with 307 redirect',
+        summary: '/y.js; 307 redirect status code, Empty ad_domain parameter; No u3 param',
+        product: 12,
+        emptyAdDomain: true,
+        customRedirect: 307
+    },     
+    16: {
+        title: '[Ad 16] SERP Ad (heuristic) with 301 redirect',
+        summary: '/y.js; 301 redirect status code, Empty ad_domain parameter; No u3 param',
+        product: 12,
+        emptyAdDomain: true,
+        customRedirect: 301
     }
 };
 


### PR DESCRIPTION
- Added two adClick tests to help validate ad attribution works when 301 and 307 redirects are used as well.
- Both the tests are based on the `[Ad 5]` test, but have different redirects used.