### PR TITLE
Add support for ad cookie checking

### DIFF
--- a/privacy-protections/storage-blocking/helpers/commonTests.js
+++ b/privacy-protections/storage-blocking/helpers/commonTests.js
@@ -1,5 +1,5 @@
 /* exported commonTests */
-/* global cookieStore, THIRD_PARTY_TRACKER_ORIGIN, THIRD_PARTY_ORIGIN */
+/* global cookieStore, THIRD_PARTY_TRACKER_ORIGIN, THIRD_PARTY_ORIGIN, THIRD_PARTY_AD_ORIGIN */
 
 function generateCookieHeaderTest (namePrefix, origin, cookiename) {
     return {
@@ -29,6 +29,8 @@ if (window.top === window.self) {
     context = 'top';
 } else if (document.location.origin === THIRD_PARTY_ORIGIN) {
     context = 'thirdparty';
+} else if (document.location.origin === THIRD_PARTY_AD_ORIGIN) {
+    context = 'thirdpartyAd';
 } else if (document.location.origin === THIRD_PARTY_TRACKER_ORIGIN) {
     context = 'thirdpartytracker';
 }

--- a/privacy-protections/storage-blocking/helpers/globals.js
+++ b/privacy-protections/storage-blocking/helpers/globals.js
@@ -1,3 +1,4 @@
-/* exported THIRD_PARTY_ORIGIN,THIRD_PARTY_TRACKER_ORIGIN */
+/* exported THIRD_PARTY_ORIGIN,THIRD_PARTY_TRACKER_ORIGIN,THIRD_PARTY_AD_ORIGIN */
 const THIRD_PARTY_ORIGIN = 'https://good.third-party.site';
 const THIRD_PARTY_TRACKER_ORIGIN = 'https://broken.third-party.site';
+const THIRD_PARTY_AD_ORIGIN = 'https://convert.ad-company.site';

--- a/privacy-protections/storage-blocking/main.js
+++ b/privacy-protections/storage-blocking/main.js
@@ -1,4 +1,4 @@
-/* globals commonTests,THIRD_PARTY_ORIGIN,THIRD_PARTY_TRACKER_ORIGIN */
+/* globals commonTests,THIRD_PARTY_ORIGIN,THIRD_PARTY_TRACKER_ORIGIN,THIRD_PARTY_AD_ORIGIN */
 
 const storeButton = document.querySelector('#store');
 const retriveButton = document.querySelector('#retrive');
@@ -82,6 +82,7 @@ function create3pIframeTest (name, origin) {
 const tests = [
     create3pIframeTest('safe', THIRD_PARTY_ORIGIN),
     create3pIframeTest('tracking', THIRD_PARTY_TRACKER_ORIGIN),
+    create3pIframeTest('ad', THIRD_PARTY_AD_ORIGIN),
     {
         id: 'browser cache',
         store: (data) => {

--- a/server.js
+++ b/server.js
@@ -73,11 +73,14 @@ function isPayHostname (req) {
 // Handle internal redirects to adClickFlow directories
 app.all('*', (req, res, next) => {
     const AD_FLOW = '/adClickFlow';
+    const PRIVACY_PROTECTIONS = '/privacy-protections';
     if (
         // If we're not a ad click flow domain ignore.
         !(isSearchHostname(req) || isAdHostname(req) || isPubHostname(req) || isPayHostname(req)) ||
         // If we've already passed to the ad dir then ignore.
-        req.path.startsWith(AD_FLOW)
+        req.path.startsWith(AD_FLOW) ||
+        // If we're a privacy protection dir then ignore.
+        req.path.startsWith(PRIVACY_PROTECTIONS)
     ) {
         next();
         return;


### PR DESCRIPTION
Adds support for checking convert.ad-company.site our testing domain for ad conversions.

The routing change is to allow the rest of the conversion code to continue to work but make a carve out for /privacy-protections (the plain domain of convert.ad-company.site has to route to /ad)

The rest of the change is just loading the iframes etc to display the cookie properties.