### PR TITLE
Remove 404'd AMP link

### DIFF
--- a/privacy-protections/amp/index.html
+++ b/privacy-protections/amp/index.html
@@ -52,10 +52,6 @@
         <p class="expected">Expected: https://www.theguardian.com/environment/2021/nov/05/british-firm-to-unveil-technology-for-zero-carbon-emission-flights-at-cop26</p>
       </li>
       <li>
-        <p><a href="https://www.euronews.com/green/amp/2021/11/05/warm-water-how-climate-change-is-affecting-the-baltic-sea">/amp link</a></p>
-        <p class="expected">Expected: https://www.euronews.com/green/2021/11/05/warm-water-how-climate-change-is-affecting-the-baltic-sea</p>
-      </li>
-      <li>
         <p><a href="https://www.independent.co.uk/news/world/americas/us-politics/fauci-dog-tests-congress-letter-b1944407.html?amp">?amp link</a></p>
         <p class="expected">Expected: https://www.independent.co.uk/news/world/americas/us-politics/fauci-dog-tests-congress-letter-b1944407.html</p>
       </li>


### PR DESCRIPTION
The euronews.com link now returns a 404 which negates its value in this test.