### PR TITLE
Add storage test for setting a cookie via the cookieStore API in a serviceworker

### DIFF
--- a/privacy-protections/storage-blocking/helpers/commonTests.js
+++ b/privacy-protections/storage-blocking/helpers/commonTests.js
@@ -158,7 +158,7 @@ const commonTests = [
         },
         extra: () => {
             if (window.cookieStore) {
-                return cookieStore.get('cookiestoredata').then(cookie => {
+                return cookieStore.get('swcookiestoredata').then(cookie => {
                     return 'expires in ' + ((cookie.expires - Date.now()) / (1000 * 60 * 60 * 24)).toFixed(2) + ' days';
                 });
             }

--- a/privacy-protections/storage-blocking/helpers/commonTests.js
+++ b/privacy-protections/storage-blocking/helpers/commonTests.js
@@ -158,7 +158,7 @@ const commonTests = [
         },
         extra: () => {
             if (window.cookieStore) {
-                return cookieStore.get('swcookiestoredata').then(cookie => {
+                return cookieStore.get('cookiestoredata').then(cookie => {
                     return 'expires in ' + ((cookie.expires - Date.now()) / (1000 * 60 * 60 * 24)).toFixed(2) + ' days';
                 });
             }

--- a/privacy-protections/storage-blocking/main.js
+++ b/privacy-protections/storage-blocking/main.js
@@ -1,4 +1,4 @@
-/* globals commonTests,THIRD_PARTY_ORIGIN,THIRD_PARTY_TRACKER_ORIGIN,THIRD_PARTY_AD_ORIGIN */
+/* globals commonTests,THIRD_PARTY_ORIGIN,THIRD_PARTY_TRACKER_ORIGIN,THIRD_PARTY_AD_ORIGIN,cookieStore */
 
 const storeButton = document.querySelector('#store');
 const retriveButton = document.querySelector('#retrive');
@@ -145,6 +145,24 @@ const tests = [
 
                     throw new Error(`Invalid response (${r.status})`);
                 });
+        }
+    },
+    {
+        id: 'service worker cookieStore',
+        store: async (data) => {
+            await navigator.serviceWorker.register(`./service-worker.js?data=${data}`, { scope: './' });
+            const resp = await fetch(`./service-worker-set-cookie?name=swcookiestoredata&data=${data}`);
+            return await resp.text();
+        },
+        retrive: async () => {
+            return (await cookieStore.get('swcookiestoredata')).value;
+        },
+        extra: () => {
+            if (window.cookieStore) {
+                return cookieStore.get('cookiestoredata').then(cookie => {
+                    return 'expires in ' + ((cookie.expires - Date.now()) / (1000 * 60 * 60 * 24)).toFixed(2) + ' days';
+                });
+            }
         }
     }
 ];

--- a/privacy-protections/storage-blocking/main.js
+++ b/privacy-protections/storage-blocking/main.js
@@ -159,7 +159,7 @@ const tests = [
         },
         extra: () => {
             if (window.cookieStore) {
-                return cookieStore.get('cookiestoredata').then(cookie => {
+                return cookieStore.get('swcookiestoredata').then(cookie => {
                     return 'expires in ' + ((cookie.expires - Date.now()) / (1000 * 60 * 60 * 24)).toFixed(2) + ' days';
                 });
             }

--- a/privacy-protections/storage-blocking/service-worker.js
+++ b/privacy-protections/storage-blocking/service-worker.js
@@ -1,4 +1,5 @@
 /* eslint-env serviceworker */
+/* global cookieStore */
 
 self.addEventListener('install', (evt) => {
     self.skipWaiting();
@@ -11,5 +12,16 @@ self.addEventListener('activate', (evt) => {
 self.addEventListener('fetch', (event) => {
     if (event.request.url.includes('/service-worker-data')) {
         event.respondWith(new Response(location.search.replace('?data=', '')));
+    }
+    if (event.request.url.includes('/service-worker-set-cookie')) {
+        const url = new URL(event.request.url);
+        if (globalThis.cookieStore) {
+            cookieStore.set({
+                name: url.searchParams.get('name'),
+                value: url.searchParams.get('data'),
+                expires: new Date('Wed, 21 Aug 2030 20:00:00 UTC').getTime()
+            });
+        }
+        event.respondWith(new Response('OK'));
     }
 });


### PR DESCRIPTION
- As the `cookieStore` API is available in serviceworkers, this can circumvent protections that rely on content-scripts.