### PR TITLE
Add test for surrogate included in head tag

### DIFF
--- a/privacy-protections/surrogates/index.html
+++ b/privacy-protections/surrogates/index.html
@@ -24,6 +24,7 @@
   color: black;
 }
 </style>
+  <script id="head-tag" src="//google-analytics.com/analytics.js"></script>
 </head>
 <p><a href="../../">[Home]</a> ↣ <a href="../">[Privacy Protections Tests]</a> ↣ <strong>[Surrogates Test Page]</strong></p>
 

--- a/privacy-protections/surrogates/main.js
+++ b/privacy-protections/surrogates/main.js
@@ -49,7 +49,7 @@ function checkSurrogate () {
 }
 
 const surrogates = {
-    'head': {
+    head: {
         notes: 'Loading surrogate in <head>',
         load: () => Promise.resolve(checkSurrogate()), // included in the html
         cleanUp: () => {
@@ -119,7 +119,7 @@ const surrogates = {
     }
 };
 
-async function injectSurrogate(testData) {
+async function injectSurrogate (testData) {
     return new Promise((resolve, reject) => {
         const s = document.createElement('script');
 
@@ -143,13 +143,13 @@ async function injectSurrogate(testData) {
         s.src = testData.url;
 
         document.body.appendChild(s);
-    })
+    });
 }
 
 (async function loadSurrogates () {
     for (const [name, testData] of Object.entries(surrogates)) {
         if (testData.url) {
-            await injectSurrogate(testData)
+            await injectSurrogate(testData);
         } else {
             testData.load().then(result => {
                 testData.test = () => result;

--- a/privacy-protections/surrogates/main.js
+++ b/privacy-protections/surrogates/main.js
@@ -116,6 +116,13 @@ const surrogates = {
 
             return promise;
         }
+    },
+    'delayed-set': {
+        notes: 'Set script src after insert',
+        url: 'https://google-analytics.com/analytics.js',
+        delay: true,
+        test: checkSurrogate,
+        cleanUp: () => { delete window.ga; }
     }
 };
 
@@ -140,9 +147,17 @@ async function injectSurrogate (testData) {
             resolve();
         };
 
-        s.src = testData.url;
+        if (!testData.delay) {
+            s.src = testData.url;
+        }
 
         document.body.appendChild(s);
+
+        if (testData.delay) {
+            setTimeout(() => {
+                s.src = testData.url;
+            }, 500);
+        }
     });
 }
 


### PR DESCRIPTION
Adds a new surrogate test to check that scripts loaded in the `head` have the surrogate correctly loaded.

This test fails on iOS and macOS. Passes on other platforms.
You can try it out at https://test.smbco.de/privacy-protections/surrogates/