### PR TITLE
Update download URL to include a HTTP redirect in spoof-js-download-url

### DIFF
--- a/security/address-bar-spoofing/spoof-js-download-url.html
+++ b/security/address-bar-spoofing/spoof-js-download-url.html
@@ -10,16 +10,20 @@
     function run() {
       const w = open()
       w.opener = null
-      w.document.write('<h1>Not Third Party Site.</h1>')
-      w.location = 'https://bad.third-party.site/features/download/file/pdf'
+      w.document.write('<h1>Not DDG.</h1>')
+      w.location = 'https://tyny.to/s509a8'
     }
   </script>
 </head>
 
 <body>
   <p><a href="./index.html">[Back]</a></p>
-  This test uses a download URL for downloading a file to spoof the browser into displaying the download
-  URL as the current origin while rewriting the document content to spoof the address bar.
+  This test uses a download URL that performs a HTTP redirect for downloading a file to trick the
+  browser into displaying the download URL as the current origin while rewriting the document content
+  resulting in a spoofed address bar.
+  The expected result is that the redirect should be followed and the file should be downloaded 
+  in the about:blank context instead of in the context of the download URL where the document might
+  be spoofed by the previous page.
   <button onclick="run()">Start</button>
 </body>
 


### PR DESCRIPTION
The vulnerability in spoof-js-download-url requires the download URL to perform a HTTP 301/302 redirect in order to spoof the address bar. 

We introduce a URL shortener link which points to a download of the macOS browser instead of the PDF link from before which sometimes renders as a PDF document inside the browser which is not the expected behaviour to exhibit the test case properly.