### PR TITLE
Rewrite download path URL to prevent URI clashes

### DIFF
--- a/security/address-bar-spoofing/server/routes.js
+++ b/security/address-bar-spoofing/server/routes.js
@@ -3,7 +3,7 @@ const router = express.Router();
 
 // Returns a 301 redirect to a download link of our browser
 // for use in the download path test
-router.get('/download-redirect', (req, res) => {
+router.get('/', (req, res) => {
     res.redirect(301, 'https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo.dmg');
 });
 

--- a/security/address-bar-spoofing/spoof-js-download-url.html
+++ b/security/address-bar-spoofing/spoof-js-download-url.html
@@ -11,7 +11,7 @@
       const w = open()
       w.opener = null
       w.document.write('<h1>Not DDG.</h1>')
-      w.location = '/security/address-bar-spoofing/download-redirect'
+      w.location = '/security/address-bar-spoofing-download-redirect'
     }
   </script>
 </head>

--- a/server.js
+++ b/server.js
@@ -285,4 +285,4 @@ const viewportRoutes = require('./viewport/server/routes.js');
 app.use('/viewport', viewportRoutes);
 
 const addressBarSpoofingRoutes = require('./security/address-bar-spoofing/server/routes.js');
-app.use('/security/address-bar-spoofing', addressBarSpoofingRoutes);
+app.use('/security/address-bar-spoofing-download-redirect', addressBarSpoofingRoutes);


### PR DESCRIPTION
I have a suspicion that there are clashes with the URI routes because we already have static routes at /security/address-bar-spoofing/ which might be overriding the download-path URL.

Instead I move `security/address-bar-spoofing/download-redirect` to `security/address-bar-spoofing-download-redirect` in the test and routes.