### PR TITLE
Update app scheme target to spreadprivacy.

### DIFF
--- a/security/address-bar-spoofing/spoof-application-scheme.html
+++ b/security/address-bar-spoofing/spoof-application-scheme.html
@@ -18,7 +18,7 @@
     <p><a href="./index.html">[Back]</a></p>
     This test uses an unsupported application scheme and a href target to trick the browser into displaying the href
     target as the current address bar value, while actually navigating to an attacker controlled page.
-    <a id="run" href="https://duckduckgo.com:" target="aa" onclick="setTimeout('run()',100)">
+    <a id="run" href="https://spreadprivacy.com:" target="aa" onclick="setTimeout('run()',100)">
         <h1>Start</h1>
     </a>
 </body>


### PR DESCRIPTION
**Task**: https://app.asana.com/0/414730916066338/1207061753348482/f

- assertVisible: "Privacy, simplified."  is not true anymore for all cases.
- duckduckgo.com has too frequent updates/experiments that affect our test assertions.

Therefore, I want to change the exploit target to spreadprivacy.com for this specific test (as other tests do not rely on specific content being visible on duckduckgo.com)