### PR TITLE
Re-add content-scope-scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@duckduckgo/privacy-test-pages",
       "dependencies": {
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts",
         "body-parser": "^1.20.1",
         "express": "^4.17.1",
         "node-cache": "^5.1.2",
@@ -124,6 +125,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@duckduckgo/content-scope-scripts": {
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#19c304704f1f72a37b64ceec545d051c4042ee3a",
+      "hasInstallScript": true,
+      "workspaces": [
+        "packages/special-pages",
+        "packages/messaging"
+      ],
+      "dependencies": {
+        "immutable-json-patch": "^5.1.3",
+        "parse-address": "^1.1.2",
+        "seedrandom": "^3.0.5",
+        "sjcl": "^1.0.8"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1734,6 +1749,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable-json-patch": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-5.1.3.tgz",
+      "integrity": "sha512-95AsF9hJTPpwtBGAnHmw57PASL672tb+vGHR5xLhH2VPuHSsLho7grjlfgQ65DIhHP+UmLCjdmuuA6L1ndJbZg=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2320,6 +2340,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-address": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/parse-address/-/parse-address-1.1.2.tgz",
+      "integrity": "sha512-EnqetXieqyTlDzuuy+oT/pjjkWoI80MgFawDA/Z9LZBAMy+Iy6piURuX+Lr1iZNm7exD+V/B9IRjHaSj33adJw==",
+      "dependencies": {
+        "xregexp": "^3.1.1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2549,6 +2577,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "node_modules/semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
@@ -2643,6 +2676,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sjcl": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
+      "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/slice-ansi": {
@@ -3046,6 +3087,11 @@
         }
       }
     },
+    "node_modules/xregexp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
+      "integrity": "sha512-tWodXkrdYZPGadukpkmhKAbyp37CV5ZiFHacIVPhRZ4/sSt7qtOYHLv2dAqcPN0mBsViY2Qai9JkO7v2TBP6hg=="
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3136,6 +3182,16 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@duckduckgo/content-scope-scripts": {
+      "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#19c304704f1f72a37b64ceec545d051c4042ee3a",
+      "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts",
+      "requires": {
+        "immutable-json-patch": "^5.1.3",
+        "parse-address": "^1.1.2",
+        "seedrandom": "^3.0.5",
+        "sjcl": "^1.0.8"
       }
     },
     "@eslint/eslintrc": {
@@ -4343,6 +4399,11 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "immutable-json-patch": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-5.1.3.tgz",
+      "integrity": "sha512-95AsF9hJTPpwtBGAnHmw57PASL672tb+vGHR5xLhH2VPuHSsLho7grjlfgQ65DIhHP+UmLCjdmuuA6L1ndJbZg=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4764,6 +4825,14 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-address": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/parse-address/-/parse-address-1.1.2.tgz",
+      "integrity": "sha512-EnqetXieqyTlDzuuy+oT/pjjkWoI80MgFawDA/Z9LZBAMy+Iy6piURuX+Lr1iZNm7exD+V/B9IRjHaSj33adJw==",
+      "requires": {
+        "xregexp": "^3.1.1"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4913,6 +4982,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
@@ -4989,6 +5063,11 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "sjcl": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
+      "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ=="
     },
     "slice-ansi": {
       "version": "4.0.0",
@@ -5278,6 +5357,11 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "requires": {}
+    },
+    "xregexp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
+      "integrity": "sha512-tWodXkrdYZPGadukpkmhKAbyp37CV5ZiFHacIVPhRZ4/sSt7qtOYHLv2dAqcPN0mBsViY2Qai9JkO7v2TBP6hg=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/duckduckgo/privacy-test-pages#readme",
   "dependencies": {
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts",
     "body-parser": "^1.20.1",
     "express": "^4.17.1",
     "node-cache": "^5.1.2",


### PR DESCRIPTION
We have a bunch of pages that should immediately become accessible after this change. (eg: https://github.com/duckduckgo/content-scope-scripts/blob/main/integration-test/test-pages/webcompat/index.html would be served from: https://privacy-test-pages.site/content-scope-scripts/web-compat/index.html) 

It's about time we re-add this back to allow this path.