### PR TITLE
Exempt Safari and WebKit-based DDG browsers from using serverTiming

### DIFF
--- a/adClickFlow/ad/convert.js
+++ b/adClickFlow/ad/convert.js
@@ -2,7 +2,7 @@ console.log('Ad conversion');
 
 const pixelUrl = new URL('./ping.gif', document.currentScript.src);
 
-function fireResource (status) {
+function fireConvertPingStatus (status) {
     window.dispatchEvent(new CustomEvent('resourceLoad', {
         detail: {
             url: pixelUrl.href,
@@ -16,9 +16,9 @@ img.src = pixelUrl;
 img.style.display = 'none';
 img.onload = () => {
     console.log('Ad conversion complete');
-    fireResource('loaded');
+    fireConvertPingStatus('loaded');
 };
 img.onerror = () => {
-    fireResource('blocked');
+    fireConvertPingStatus('blocked');
 };
 document.body.appendChild(img);

--- a/adClickFlow/ad/track.js
+++ b/adClickFlow/ad/track.js
@@ -1,7 +1,8 @@
 console.log('Tracking');
 
 const trackingImgUrl = new URL('./ping.gif', document.currentScript.src);
-function fireResource (status) {
+
+function fireTrackingPingStatus (status) {
     window.dispatchEvent(new CustomEvent('resourceLoad', {
         detail: {
             url: trackingImgUrl.href,
@@ -14,9 +15,9 @@ const trackingImg = document.createElement('img');
 trackingImg.src = trackingImgUrl;
 trackingImg.style.display = 'none';
 trackingImg.onload = () => {
-    fireResource('loaded');
+    fireTrackingPingStatus('loaded');
 };
 trackingImg.onerror = () => {
-    fireResource('blocked');
+    fireTrackingPingStatus('blocked');
 };
 document.body.appendChild(trackingImg);

--- a/adClickFlow/shared/utils.mjs
+++ b/adClickFlow/shared/utils.mjs
@@ -14,6 +14,10 @@ function getAdHostname (hostname) {
     return isLocalTest ? 'ad-company.example' : 'ad-company.site';
 }
 
+function isSafariOrDDG() {
+    return navigator.vendor && navigator.vendor.indexOf('Apple') > -1;
+}
+
 function getAdUrl (id, hostname) {
     // Build Ad Redirection URL
     const adHostname = getAdHostname(hostname);
@@ -341,8 +345,8 @@ export class FinishObserver {
         this.observer = new PerformanceObserver((list) => {
             const entries = list.getEntries();
             entries.map((entry) => {
-                // Safari doesn't support serverTiming nor does it fire events for blocked loads either.
-                if (entry.serverTiming) {
+                // WebKit doesn't seem to support serverTiming for cross-origin loads
+                if (entry.serverTiming && !isSafariOrDDG()) {
                     if (entry.serverTiming.length === 0) {
                         this.setResourceStatus(entry.name, 'blocked');
                     } else {


### PR DESCRIPTION
https://app.asana.com/0/1186013049913869/1205272059194928/f

Looks like Safari added serverTiming support last year, which led to two code paths checking for the success of the load running. From what I can tell, they don't support it for cross-origin loads though, so one code path will always return `blocked`. This was leading to a race condition between the two measurement methods and inconsistent output.

I also renamed the two `fireResource` methods within the injected scripts, since I saw some timing inconsistency there as well from the naming conflict.