### PR TITLE
Add URL canonicalization tests.

### DIFF
--- a/security/url-canonicalization.html
+++ b/security/url-canonicalization.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>URL Canonicalization Tests</title>
+</head>
+<body>
+    <p><a href="../index.html">[Back]</a></p>
+    <h1>URL Canonicalization Tests</h1>
+    Each of the following links, when clicked, should raise an error page. It should never actually load the page - if it does, this indicates that our URL canonicalization has failed, which could potentially allow malformed or malicious URLs to be processed incorrectly.
+    <a id="test_specialchar1" href="https://www.%20privacy-test-pages.glitch.me/security/badware/phishing.html" target="_blank">Special Characters</a><br>
+    <a id="test_specialchar2" href="https://www.%7Eprivacy-test-pages.glitch.me/security/badware/phishing.html" target="_blank">Special Characters</a><br>
+    <a id="test_outofrangechars" href="https://www.🙃privacy-test-pages.glitch.me/security/badware/phishing.html" target="_blank">Out-of-Range Characters</a><br>
+    <a id="test_percentescapes" href="https://www.privacy-test-pages.glitch.me%20security%20badware/phishing.html" target="_blank">Percent Escapes</a><br>
+    <a id="test_doubledots" href="https://www..privacy-test-pages.glitch.me/security/badware/phishing.html" target="_blank">Multiple Full Stops</a><br>
+    <a id="test_trailingdots" href="https://www.privacy-test-pages.glitch.me./security/badware/phishing.html" target="_blank">Trailing Full Stops</a><br>
+</body>
+</html>

--- a/security/url-canonicalization.html
+++ b/security/url-canonicalization.html
@@ -9,11 +9,12 @@
     <p><a href="../index.html">[Back]</a></p>
     <h1>URL Canonicalization Tests</h1>
     Each of the following links, when clicked, should raise an error page. It should never actually load the page - if it does, this indicates that our URL canonicalization has failed, which could potentially allow malformed or malicious URLs to be processed incorrectly.
-    <a id="test_specialchar1" href="https://www.%20privacy-test-pages.glitch.me/security/badware/phishing.html" target="_blank">Special Characters</a><br>
-    <a id="test_specialchar2" href="https://www.%7Eprivacy-test-pages.glitch.me/security/badware/phishing.html" target="_blank">Special Characters</a><br>
-    <a id="test_outofrangechars" href="https://www.🙃privacy-test-pages.glitch.me/security/badware/phishing.html" target="_blank">Out-of-Range Characters</a><br>
-    <a id="test_percentescapes" href="https://www.privacy-test-pages.glitch.me%20security%20badware/phishing.html" target="_blank">Percent Escapes</a><br>
-    <a id="test_doubledots" href="https://www..privacy-test-pages.glitch.me/security/badware/phishing.html" target="_blank">Multiple Full Stops</a><br>
-    <a id="test_trailingdots" href="https://www.privacy-test-pages.glitch.me./security/badware/phishing.html" target="_blank">Trailing Full Stops</a><br>
+    <a id="test_specialchar1" href="https://www.%20privacy-test-pages.site/security/badware/phishing.html" target="_blank">Special Characters</a><br>
+    <a id="test_specialchar2" href="https://www.%7Eprivacy-test-pages.site/security/badware/phishing.html" target="_blank">Special Characters</a><br>
+    <a id="test_outofrangechars" href="https://www.🙃privacy-test-pages.site/security/badware/phishing.html" target="_blank">Out-of-Range Characters</a><br>
+    <a id="test_percentescapes" href="https://www.privacy-test-pages.site%20security%20badware/phishing.html" target="_blank">Percent Escapes</a><br>
+    <a id="test_doubledots" href="https://broken..third-party.site/security/badware/phishing.html" target="_blank">Multiple Full Stops</a><br>
+    <a id="test_trailingdots" href="https://bad.third-party.site./security/badware/phishing.html" target="_blank">Trailing Full Stops</a><br>
+    <a id="test_trailingdots" href="https://.broken.third-party.site/security/badware/phishing.html" target="_blank">Leading Full Stops</a><br>
 </body>
 </html>


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1207138193507367/f

Our browsers are soon to be implementing URL canonicalization and we need a series of tests to ensure this is working as expected. Here we introduce several test cases based on the algorithm defined in the above Asana tasks. The aim is that each of these should be clicked, and the page _should never load_. If it loads, it indicates that our URL canonicalization is broken.

_Note_: this cannot be tested yet, soon a macOS PR will test against this.