### PR TITLE
Add extra phishing detection test pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,8 +60,8 @@
 	<li><a href="./security/dos-reload.html">Infinite location.reload() loop</a></li>
 	<li><a href="./security/csp-report/index.html">Leak of extension IDs via CSP</a></li>
 	<li><a href="./security/js-leaks.html">Detect changes to JS objects in global scope</a></li>
-	<li><a href="./security/badware/phishing.html">An example phishing page</a></li>
 	<li><a href="./security/popups/popup-launcher.html">Popup noopener/noreferrer tests</a></li>
+	<li><a href="./security/badware/">Phishing Detection Pages</a></li>
 </ul>
 
 <h2>Privacy Protections Tests</h2>

--- a/security/badware/index.html
+++ b/security/badware/index.html
@@ -15,12 +15,19 @@
         <li><a href="./phishing-js-redirector-helper.html">Phishing JS Redirector (Direct)</a></li>
         <li><a href="./phishing-js-redirector.html">Phishing JS Redirector (Indirect)</a></li>
         <li><a href="./phishing-legit-iframe-loader.html">Phishing Legit iFrame Loader</a></li>
+        <li><a href="./phishing-meta-redirect-clean.html">Phishing Redirect via Meta Refresh (Not Flagged in Dataset)</a></li>
+        <li><a href="./phishing-meta-redirect.html">Phishing Redirect via Meta Refresh (Flagged in Dataset)</a></li>
+        <li><a href="./phishing-popups.html">Phishing Open via Popups</a></li>
+        <li><a href="./phishing-url-tampering.html">Phishing Opening with URL Tampering</a></li>
         <li><a href="/security/badware/phishing-redirect/">HTTP 301 Redirect to Main Phishing Test Page</a></li>
         <li><a href="/security/badware/phishing-redirect/302">HTTP 302 Redirect to Main Phishing Test Page</a></li>
         <li><a href="/security/badware/phishing-redirect/js">HTTP Redirect to Phishing JS Redirector (Indirect)</a></li>
         <li><a href="/security/badware/phishing-redirect/js2">HTTP Redirect to Phishing JS Redirector (Direct)</a></li>
         <li><a href="/security/badware/phishing-redirect/iframe">HTTP Redirect to Phishing iFrame Loader</a></li>
         <li><a href="/security/badware/phishing-redirect/iframe2">HTTP Redirect to Phishing Legit iFrame Loader</a></li>
+        <li><a href="/security/badware/phishing-redirect/meta">HTTP Redirect to Clean Meta Refresh Redirector</a></li>
+        <li><a href="/security/badware/phishing-redirect/meta2">HTTP Redirect to Flagged Meta Refresh Redirector</a></li>
+
     </ul>
 </body>
 

--- a/security/badware/index.html
+++ b/security/badware/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>Test Pages - Phishing Detection</title>
+</head>
+
+<body>
+    <h1>Phishing Detection Test Pages</h1>
+    <a href="/">[Home]</a>
+    <ul>
+        <li><a href="./phishing.html">Standard Phishing Test</a></li>
+        <li><a href="./phishing-iframe-loader.html">Phishing iFrame Loader</a></li>
+        <li><a href="./phishing-js-redirector-helper.html">Phishing JS Redirector (Direct)</a></li>
+        <li><a href="./phishing-js-redirector.html">Phishing JS Redirector (Indirect)</a></li>
+        <li><a href="./phishing-legit-iframe-loader.html">Phishing Legit iFrame Loader</a></li>
+        <li><a href="/security/badware/phishing-redirect/">HTTP 301 Redirect to Main Phishing Test Page</a></li>
+        <li><a href="/security/badware/phishing-redirect/302">HTTP 302 Redirect to Main Phishing Test Page</a></li>
+        <li><a href="/security/badware/phishing-redirect/js">HTTP Redirect to Phishing JS Redirector (Indirect)</a></li>
+        <li><a href="/security/badware/phishing-redirect/js2">HTTP Redirect to Phishing JS Redirector (Direct)</a></li>
+        <li><a href="/security/badware/phishing-redirect/iframe">HTTP Redirect to Phishing iFrame Loader</a></li>
+        <li><a href="/security/badware/phishing-redirect/iframe2">HTTP Redirect to Phishing Legit iFrame Loader</a></li>
+    </ul>
+</body>
+
+</html>

--- a/security/badware/index.html
+++ b/security/badware/index.html
@@ -19,6 +19,10 @@
         <li><a href="./phishing-meta-redirect.html">Phishing Redirect via Meta Refresh (Flagged in Dataset)</a></li>
         <li><a href="./phishing-popups.html">Phishing Open via Popups</a></li>
         <li><a href="./phishing-url-tampering.html">Phishing Opening with URL Tampering</a></li>
+        <li><a href="./phishing-form-submission.html">Phishing Form Submission</a></li>
+        <li><a href="./phishing-iframe-top-navigator.html">Phishing iFrame Top Navigator</a></li>
+        <li><a href="./phishing-service-worker.html">Phishing Service Worker</a></li>
+        <li><a href="./phishing-iframe-top-navigator-parent.html">Phishing iFrame Top Navigator Parent</a></li>
         <li><a href="/security/badware/phishing-redirect/">HTTP 301 Redirect to Main Phishing Test Page</a></li>
         <li><a href="/security/badware/phishing-redirect/302">HTTP 302 Redirect to Main Phishing Test Page</a></li>
         <li><a href="/security/badware/phishing-redirect/js">HTTP Redirect to Phishing JS Redirector (Indirect)</a></li>

--- a/security/badware/phishing-form-submission.html
+++ b/security/badware/phishing-form-submission.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Phishing Form Submission</title>
+</head>
+
+<body>
+    <p><a href="./index.html">[Back]</a></p>
+
+    <h1>Phishing Page Form Submission</h1>
+
+    <p>This is an example page that, although it is not in our phishing dataset, it submits a form to an endpoint that is in our phishing dataset. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our
+        client blocking is working.</p>
+    <form method="post" action="/security/badware/phishing-redirect/form">
+        <input type="hidden" name="phishing" value="true">
+        <input type="submit" value="Submit">
+    </form>
+</body>
+
+</html>

--- a/security/badware/phishing-iframe-loader.html
+++ b/security/badware/phishing-iframe-loader.html
@@ -7,7 +7,7 @@
 <body>
 <p><a href="./index.html">[Back]</a></p>
 
-<h1>Phishing page</h1>
+<h1>Phishing Page iFrame Loader</h1>
 
 <p>This is an example page that, although it is not in our phishing dataset, it loads a test phishing page in an iframe. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is working.</p>
 <iframe src="https://bad.third-party.site/security/badware/phishing.html" width="100%" height="500" title="Phishing Page"></iframe>

--- a/security/badware/phishing-iframe-loader.html
+++ b/security/badware/phishing-iframe-loader.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Phishing page loaded in iframe</title>
+</head>
+<body>
+<p><a href="./index.html">[Back]</a></p>
+
+<h1>Phishing page</h1>
+
+<p>This is an example page that, although it is not in our phishing dataset, it loads a test phishing page in an iframe. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is working.</p>
+<iframe src="https://bad.third-party.site/security/badware/phishing.html" width="100%" height="500" title="Phishing Page"></iframe>
+</body>
+</html>

--- a/security/badware/phishing-iframe-top-navigator-parent.html
+++ b/security/badware/phishing-iframe-top-navigator-parent.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Phishing Page iFrame Top Navigator</title>
+    <script>
+        if (window.top !== window.self) {
+            window.top.location.href = "https://bad.third-party.site/security/badware/phishing.html";
+        }
+    </script>
+</head>
+<body>
+<p><a href="./index.html">[Back]</a></p>
+
+<h1>Phishing Page iFrame Top Navigator Parent</h1>
+
+<p>This is an example page that, although it is not in our phishing dataset, it loads an iframe that performs a top-navigation to a phishing page. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is working.</p>
+<iframe src="https://bad.third-party.site/security/badware/phishing-iframe-top-navigator.html" width="100%" height="500" title="Phishing Page"></iframe>
+</body>
+</html>

--- a/security/badware/phishing-iframe-top-navigator.html
+++ b/security/badware/phishing-iframe-top-navigator.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Phishing Page iFrame Top Navigator</title>
+    <script>
+        if (window.top !== window.self) {
+            window.top.location.href = "https://bad.third-party.site/security/badware/phishing.html";
+        }
+    </script>
+</head>
+<body>
+<p><a href="./index.html">[Back]</a></p>
+
+<h1>Phishing Page iFrame Top Navigator</h1>
+
+<p>This is an example page that, although it is not in our phishing dataset, when iframed, it performs a top-navigation to a phishing page. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is working.</p>
+
+</body>
+</html>

--- a/security/badware/phishing-js-redirector-helper.html
+++ b/security/badware/phishing-js-redirector-helper.html
@@ -11,7 +11,7 @@
 <body>
 <p><a href="./index.html">[Back]</a></p>
 
-<h1>Phishing page</h1>
+<h1>Phishing Page JS Redirects (Direct)</h1>
 
 <p>This is a helper page that is used to redirect to a page that should be classified as phishing. This page itself should not be classified as phishing in our datasets, but since it redirects to a page that is, the error page should still be shown. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is
 working.</p>

--- a/security/badware/phishing-js-redirector-helper.html
+++ b/security/badware/phishing-js-redirector-helper.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Phishing page with JS redirect loop - helper page</title>
+    <script>
+        // eslint-disable-next-line no-unused-vars
+        window.location = '/security/badware/phishing.html';
+    </script>
+</head>
+<body>
+<p><a href="./index.html">[Back]</a></p>
+
+<h1>Phishing page</h1>
+
+<p>This is a helper page that is used to redirect to a page that should be classified as phishing. This page itself should not be classified as phishing in our datasets, but since it redirects to a page that is, the error page should still be shown. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is
+working.</p>
+</body>
+</html>

--- a/security/badware/phishing-js-redirector.html
+++ b/security/badware/phishing-js-redirector.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Phishing page with JS redirect loop</title>
+    <script>
+        // eslint-disable-next-line no-unused-vars
+        window.location = '/security/badware/phishing-js-redirector-helper.html';
+    </script>
+</head>
+<body>
+<p><a href="./index.html">[Back]</a></p>
+
+<h1>Phishing page</h1>
+
+<p>This is an example phishing page that attempts to load legitimate iframes to trick the browser into incorrectly classifying the page as legitimate when it should be classed as malware. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is
+working.</p>
+</body>
+</html>

--- a/security/badware/phishing-js-redirector.html
+++ b/security/badware/phishing-js-redirector.html
@@ -11,7 +11,7 @@
 <body>
 <p><a href="./index.html">[Back]</a></p>
 
-<h1>Phishing page</h1>
+<h1>Phishing Page JS Redirects (Indirect)</h1>
 
 <p>This is an example phishing page that attempts to load legitimate iframes to trick the browser into incorrectly classifying the page as legitimate when it should be classed as malware. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is
 working.</p>

--- a/security/badware/phishing-legit-iframe-loader.html
+++ b/security/badware/phishing-legit-iframe-loader.html
@@ -7,7 +7,7 @@
 <body>
 <p><a href="./index.html">[Back]</a></p>
 
-<h1>Phishing page</h1>
+<h1>Phishing Page - iFrame Spoofing</h1>
 
 <p>This is an example phishing page that attempts to load legitimate iframes to trick the browser into incorrectly classifying the page as legitimate when it should be classified as phishing. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is
 working.</p>

--- a/security/badware/phishing-legit-iframe-loader.html
+++ b/security/badware/phishing-legit-iframe-loader.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Phishing page loaded in iframe</title>
+</head>
+<body>
+<p><a href="./index.html">[Back]</a></p>
+
+<h1>Phishing page</h1>
+
+<p>This is an example phishing page that attempts to load legitimate iframes to trick the browser into incorrectly classifying the page as legitimate when it should be classified as phishing. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is
+working.</p>
+<iframe src="/" width="100%" height="500" title="Phishing Page"></iframe>
+<iframe src="about:blank" width="100%" height="500" title="Phishing Page"></iframe>
+</body>
+</html>

--- a/security/badware/phishing-meta-redirect-clean.html
+++ b/security/badware/phishing-meta-redirect-clean.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=/security/badware/phishing.html">
+    <title>Phishing page</title>
+</head>
+
+<body>
+    <p><a href="./index.html">[Back]</a></p>
+
+    <h1>Phishing Redirect via Meta Refresh</h1>
+
+    <p>This is an example page that loads a phishing page via a meta refresh to test how the browser responds. If you arrive here by mistake; there's
+        nothing to worry about, we just use this page to test if our client blocking is working.</p>
+
+</body>
+
+</html>

--- a/security/badware/phishing-meta-redirect.html
+++ b/security/badware/phishing-meta-redirect.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=/security/badware/phishing.html">
+    <title>Phishing page</title>
+</head>
+
+<body>
+    <p><a href="./index.html">[Back]</a></p>
+
+    <h1>Phishing Redirect via Meta Refresh</h1>
+
+    <p>This is an example page that loads a phishing page via a meta refresh to test how the browser responds. If you arrive here by mistake; there's
+        nothing to worry about, we just use this page to test if our client blocking is working.</p>
+
+</body>
+
+</html>

--- a/security/badware/phishing-popups.html
+++ b/security/badware/phishing-popups.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Phishing Page via Popups</title>
+    <script>
+        // eslint-disable-next-line no-unused-vars
+        function openPopup(target) {
+            window.open('/security/badware/phishing.html', target);
+        }
+    </script>
+</head>
+
+<body>
+    <p><a href="./index.html">[Back]</a></p>
+
+    <h1>Phishing Page Opener via Popups</h1>
+
+    <p>This is an example page that opens phishing pages via various pop-ups with different target types to test the in-browser phishing detection blocking. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is
+    working.</p>
+
+    <h2>Test Popups</h2>
+    <button onclick="openPopup('_blank')">Open Phishing Popup (_blank)</button>
+    <button onclick="openPopup('_self')">Open Phishing Popup (_self)</button>
+    <button onclick="openPopup('_parent')">Open Phishing Popup (_parent)</button>
+    <button onclick="openPopup('_top')">Open Phishing Popup (_top)</button>
+    <button onclick="openPopup('')">Open Phishing Popup (no target)</button>
+    <button onclick="openPopup('invalid')">Open Phishing Popup (invalid target)</button>
+</body>
+
+</html>

--- a/security/badware/phishing-service-worker.html
+++ b/security/badware/phishing-service-worker.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Phishing Page Service Worker</title>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/security/badware/service-worker.js')
+                    .then(registration => {
+                        console.log('Service Worker registered with scope:', registration.scope);
+                    })
+                    .catch(error => {
+                        console.error('Service Worker registration failed:', error);
+                    });
+            });
+
+            navigator.serviceWorker.addEventListener('message', event => {
+                console.log('Message from Service Worker:', event.data);
+            });
+
+            document.addEventListener('click', function (event) {
+                if (event.target.id === 'navigate') {
+                    if (navigator.serviceWorker.controller) {
+                        navigator.serviceWorker.controller.postMessage('navigate');
+                    } else {
+                        console.error('No active Service Worker controller found.');
+                    }
+                }
+            });
+
+            document.addEventListener('click', function (event) {
+                if (event.target.id === 'fetch') {
+                    if (navigator.serviceWorker.controller) {
+                        navigator.serviceWorker.controller.postMessage('fetch');
+                    } else {
+                        console.error('No active Service Worker controller found.');
+                    }
+                }
+            });
+        }
+    </script>
+</head>
+
+<body>
+    <p><a href="./index.html">[Back]</a></p>
+
+    <h1>Phishing Page Service Worker</h1>
+
+    <p>This is an example page that attempts to abuse a service worker to navigate to a phishing page. If you arrive
+        here by mistake; there's
+        nothing to worry about, we just use this page to test if our client blocking is working.</p>
+    <button id="navigate">Service Worker Navigate</button>
+    <button id="fetch">Service Worker Fetch</button>
+</body>
+
+</html>

--- a/security/badware/phishing-url-tampering.html
+++ b/security/badware/phishing-url-tampering.html
@@ -31,6 +31,7 @@
     }
 
     function percentEncodeURL() {
+      // Inject percent-encoded characters into the URL to bypass phishing detection
       window.location = "/%73%65%63%75%72%69%74%79/%62%61%64%77%61%72%65/%70%68%69%73%68%69%6e%67%2e%68%74%6d%6c"
     }
   </script>

--- a/security/badware/phishing-url-tampering.html
+++ b/security/badware/phishing-url-tampering.html
@@ -34,6 +34,11 @@
       // Inject percent-encoded characters into the URL to bypass phishing detection
       window.location = "/%73%65%63%75%72%69%74%79/%62%61%64%77%61%72%65/%70%68%69%73%68%69%6e%67%2e%68%74%6d%6c"
     }
+
+    function capitalizeURL() {
+      // Capitalize the URL to bypass phishing detection
+      window.location = '/SECURITY/BADWARE/PHISHING.HTML';
+    }
   </script>
 </head>
 <body>
@@ -48,5 +53,6 @@
 <button onclick="injectedDoublePaths()">Injected Double Paths</button>
 <button onclick="injectedSinglePaths()">Injected Single Paths</button>
 <button onclick="percentEncodeURL()">Percent Encode URL</button>
+<button onclick="capitalizeURL()">Capitalize URL</button>
 </body>
 </html>

--- a/security/badware/phishing-url-tampering.html
+++ b/security/badware/phishing-url-tampering.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Phishing Page with URL Tampering</title>
+  <script>
+    // eslint-disable-next-line no-unused-vars
+    function injectedWhitespace() {
+      // Inject tab (0x09), CR (0x0d), and LF (0x0a) characters into the URL to bypass phishing detection
+      window.location = '/security/badware/phishing.html\t\r\n';
+    }
+
+    function injectedMiddleWhitespace() {
+      // Inject tab (0x09), CR (0x0d), and LF (0x0a) characters into the URL to bypass phishing detection
+      window.location = '/security/badware/\t\r\n\tphishing.html';
+    }
+
+    function injectedFragments() {
+      // Inject #frags into the URL to bypass phishing detection
+      window.location = '/security/badware/phishing.html#frags';
+    }
+
+    function injectedDoublePaths() {
+      // Inject "/../" in the path to bypass phishing detection
+      window.location = '/security/../security/badware/phishing.html';
+    }
+
+    function injectedSinglePaths() {
+      // Inject /./ in the path to bypass phishing detection
+      window.location = '/security/./badware/phishing.html';
+    }
+
+    function percentEncodeURL() {
+      window.location = "/%73%65%63%75%72%69%74%79/%62%61%64%77%61%72%65/%70%68%69%73%68%69%6e%67%2e%68%74%6d%6c"
+    }
+  </script>
+</head>
+<body>
+  <p><a href="./index.html">[Back]</a></p>
+
+<h1>Phishing Opening via URL Tampering</h1>
+
+<p>This is an example malicious page that attempts to open phishing pages with tampered URLs to bypass the phishing detection logic. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is working.</p>
+<button onclick="injectedWhitespace()">Injected Whitespace</button>
+<button onclick="injectedMiddleWhitespace()">Injected Middle Whitespace</button>
+<button onclick="injectedFragments()">Injected Fragments</button>
+<button onclick="injectedDoublePaths()">Injected Double Paths</button>
+<button onclick="injectedSinglePaths()">Injected Single Paths</button>
+<button onclick="percentEncodeURL()">Percent Encode URL</button>
+</body>
+</html>

--- a/security/badware/phishing.html
+++ b/security/badware/phishing.html
@@ -5,7 +5,7 @@
   <title>Phishing page</title>
 </head>
 <body>
-<p><a href="../../index.html">[Home]</a></p>
+  <p><a href="./index.html">[Back]</a></p>
 
 <h1>Phishing page</h1>
 

--- a/security/badware/server/routes.js
+++ b/security/badware/server/routes.js
@@ -1,59 +1,59 @@
-const express = require("express");
+const express = require('express');
 const router = express.Router();
 
 // Returns a 301 redirect to the main phishing test page
-router.get("/", (req, res) => {
-  res.redirect(
-    301,
-    "/security/badware/phishing.html"
-  );
+router.get('/', (req, res) => {
+    res.redirect(
+        301,
+        '/security/badware/phishing.html'
+    );
 });
 
 // Returns a 302 redirect to the main phishing test page
-router.get("/302", (req, res) => {
-  res.redirect(
-    302,
-    "/security/badware/phishing.html"
-  );
+router.get('/302', (req, res) => {
+    res.redirect(
+        302,
+        '/security/badware/phishing.html'
+    );
 });
 
 // Returns a 301 redirect to a JS redirector page
-router.get("/js", (req, res) => {
+router.get('/js', (req, res) => {
     res.redirect(
         301,
-        "/security/badware/phishing-js-redirector.html"
-    )
+        '/security/badware/phishing-js-redirector.html'
+    );
 });
 
 // Returns a 301 redirect to a JS redirector helper page
-router.get("/js2", (req, res) => {
+router.get('/js2', (req, res) => {
     res.redirect(
         301,
-        "/security/badware/phishing-js-redirector-helper.html"
-    )
+        '/security/badware/phishing-js-redirector-helper.html'
+    );
 });
 
 // Returns a redirect to a page that loads an iframe that renders a phishing page
-router.get("/iframe", (req, res) => {
+router.get('/iframe', (req, res) => {
     res.redirect(
         301,
-        "/security/badware/phishing-iframe-loader.html"
-    )
+        '/security/badware/phishing-iframe-loader.html'
+    );
 });
 
 // Returns a redirect to a page that loads multiple iframes to attempt to bypass the phishing detection
-router.get("/iframe2", (req, res) => {
-  res.redirect(301, "/security/badware/phishing-legit-iframe-loader.html");
+router.get('/iframe2', (req, res) => {
+    res.redirect(301, '/security/badware/phishing-legit-iframe-loader.html');
 });
 
 // Returns a redirect to a page that renders a phishing page using a meta refresh (not flagged in dataset)
-router.get("/meta", (req, res) => {
-  res.redirect(301, "/security/badware/phishing-meta-redirect-clean.html");
+router.get('/meta', (req, res) => {
+    res.redirect(301, '/security/badware/phishing-meta-redirect-clean.html');
 });
 
 // Returns a redirect to a page that renders a phishing page using a meta refresh (flagged in dataset)
-router.get("/meta2", (req, res) => {
-  res.redirect(301, "/security/badware/phishing-meta-redirect.html");
+router.get('/meta2', (req, res) => {
+    res.redirect(301, '/security/badware/phishing-meta-redirect.html');
 });
 
 module.exports = router;

--- a/security/badware/server/routes.js
+++ b/security/badware/server/routes.js
@@ -56,4 +56,9 @@ router.get('/meta2', (req, res) => {
     res.redirect(301, '/security/badware/phishing-meta-redirect.html');
 });
 
+// Form handler for the phishing form
+router.post('/form', (req, res) => {
+    res.send('Form submitted');
+});
+
 module.exports = router;

--- a/security/badware/server/routes.js
+++ b/security/badware/server/routes.js
@@ -1,0 +1,49 @@
+const express = require("express");
+const router = express.Router();
+
+// Returns a 301 redirect to the main phishing test page
+router.get("/", (req, res) => {
+  res.redirect(
+    301,
+    "/security/badware/phishing.html"
+  );
+});
+
+// Returns a 302 redirect to the main phishing test page
+router.get("/302", (req, res) => {
+  res.redirect(
+    302,
+    "/security/badware/phishing.html"
+  );
+});
+
+// Returns a 301 redirect to a JS redirector page
+router.get("/js", (req, res) => {
+    res.redirect(
+        301,
+        "/security/badware/phishing-js-redirector.html"
+    )
+});
+
+// Returns a 301 redirect to a JS redirector helper page
+router.get("/js2", (req, res) => {
+    res.redirect(
+        301,
+        "/security/badware/phishing-js-redirector-helper.html"
+    )
+});
+
+// Returns a redirect to a page that loads an iframe that renders a phishing page
+router.get("/iframe", (req, res) => {
+    res.redirect(
+        301,
+        "/security/badware/phishing-iframe-loader.html"
+    )
+});
+
+// Returns a redirect to a page that loads multiple iframes to attempt to bypass the phishing detection
+router.get("/iframe2", (req, res) => {
+  res.redirect(301, "/security/badware/phishing-legit-iframe-loader.html");
+});
+
+module.exports = router;

--- a/security/badware/server/routes.js
+++ b/security/badware/server/routes.js
@@ -46,4 +46,14 @@ router.get("/iframe2", (req, res) => {
   res.redirect(301, "/security/badware/phishing-legit-iframe-loader.html");
 });
 
+// Returns a redirect to a page that renders a phishing page using a meta refresh (not flagged in dataset)
+router.get("/meta", (req, res) => {
+  res.redirect(301, "/security/badware/phishing-meta-redirect-clean.html");
+});
+
+// Returns a redirect to a page that renders a phishing page using a meta refresh (flagged in dataset)
+router.get("/meta2", (req, res) => {
+  res.redirect(301, "/security/badware/phishing-meta-redirect.html");
+});
+
 module.exports = router;

--- a/security/badware/service-worker.js
+++ b/security/badware/service-worker.js
@@ -1,0 +1,44 @@
+self.addEventListener("install", (event) => {
+  console.log("Service Worker installing.");
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  console.log("Service Worker activating.");
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data === "navigate") {
+    console.log("Service Worker received navigate message.");
+    self.clients.matchAll({ type: "window" }).then((clients) => {
+      clients.forEach((client) => {
+        if ("navigate" in client) {
+          client
+            .navigate("/security/badware/phishing.html")
+            .then(() => {
+              console.log("Navigation attempt to phishing page.");
+            })
+            .catch((error) => {
+              console.error("Navigation failed:", error);
+            });
+        }
+      });
+    });
+  } else if (event.data === "fetch") {
+    console.log("Service Worker received fetch message.");
+    fetch("https://bad.third-party.site/security/badware/phishing.html")
+      .then((response) => {
+        if (response.ok) {
+          console.log("Phishing page fetched successfully.");
+        } else {
+          console.log("Failed to fetch phishing page.");
+        }
+      })
+      .catch((error) => {
+        console.error("Error fetching phishing page:", error);
+      });
+  } else {
+    console.log("Service Worker received unknown message:", event.data);
+  }
+});

--- a/security/badware/service-worker.js
+++ b/security/badware/service-worker.js
@@ -1,44 +1,43 @@
-self.addEventListener("install", (event) => {
-  console.log("Service Worker installing.");
-  self.skipWaiting();
+self.addEventListener('install', () => {
+    console.log('Service Worker installing.');
+    self.skipWaiting();
 });
 
-self.addEventListener("activate", (event) => {
-  console.log("Service Worker activating.");
-  event.waitUntil(self.clients.claim());
+self.addEventListener('activate', () => {
+    console.log('Service Worker activating.');
+    self.clients.claim();
 });
 
-self.addEventListener("message", (event) => {
-  if (event.data === "navigate") {
-    console.log("Service Worker received navigate message.");
-    self.clients.matchAll({ type: "window" }).then((clients) => {
-      clients.forEach((client) => {
-        if ("navigate" in client) {
-          client
-            .navigate("/security/badware/phishing.html")
-            .then(() => {
-              console.log("Navigation attempt to phishing page.");
+self.addEventListener('message', (event) => {
+    if (event.data === 'navigate') {
+        console.log('Service Worker received navigate message.');
+        self.clients.matchAll({ type: 'window' }).then((clients) => {
+            clients.forEach((client) => {
+                if ('navigate' in client) {
+                    client.navigate('/security/badware/phishing.html')
+                        .then(() => {
+                            console.log('Navigation attempt to phishing page.');
+                        })
+                        .catch((error) => {
+                            console.error('Navigation failed:', error);
+                        });
+                }
+            });
+        });
+    } else if (event.data === 'fetch') {
+        console.log('Service Worker received fetch message.');
+        fetch('https://bad.third-party.site/security/badware/phishing.html')
+            .then((response) => {
+                if (response.ok) {
+                    console.log('Phishing page fetched successfully.');
+                } else {
+                    console.log('Failed to fetch phishing page.');
+                }
             })
             .catch((error) => {
-              console.error("Navigation failed:", error);
+                console.error('Error fetching phishing page:', error);
             });
-        }
-      });
-    });
-  } else if (event.data === "fetch") {
-    console.log("Service Worker received fetch message.");
-    fetch("https://bad.third-party.site/security/badware/phishing.html")
-      .then((response) => {
-        if (response.ok) {
-          console.log("Phishing page fetched successfully.");
-        } else {
-          console.log("Failed to fetch phishing page.");
-        }
-      })
-      .catch((error) => {
-        console.error("Error fetching phishing page:", error);
-      });
-  } else {
-    console.log("Service Worker received unknown message:", event.data);
-  }
+    } else {
+        console.log('Service Worker received unknown message:', event.data);
+    }
 });

--- a/server.js
+++ b/server.js
@@ -286,3 +286,6 @@ app.use('/viewport', viewportRoutes);
 
 const addressBarSpoofingRoutes = require('./security/address-bar-spoofing/server/routes.js');
 app.use('/security/address-bar-spoofing-download-redirect', addressBarSpoofingRoutes);
+
+const phishingDetectionRoutes = require('./security/badware/server/routes.js');
+app.use('/security/badware/phishing-redirect', phishingDetectionRoutes);


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1204023833050360/1207879877788852/f

Add several new abusive test cases for testing phishing detection:
1. JS redirector (that redirects to a phishing page) - should **not** be added to phishing dataset
2. JS redirector indirect (redirects to the page above) - should be added to phishing dataset
3. iframe loader (loads phishing page in iframe) - should **not** be added to phishing dataset
4. iframe loader (loads legit pages in iframe) - should be added to phishing dataset
5. 301 redirects to all of the above (via HTTP redirectors) - should **not** be added to phishing dataset
6. 301 redirect to the main phishing test page - should **not** be added to phishing dataset
7. 302 redirect to the main phishing test page - should be added to phishing dataset
8. Popups with varying targets to phishing test page - should **not** be added to phishing dataset
9. Meta refresh redirector to phishing page - should **not** be added to phishing dataset
10. Meta refresh redirector to phishing page - should be added to phishing dataset
11. URL tampering via encoding / whitespace + path + fragment injection - should **not** be added to phishing dataset
12. iFrame top navigator - should not be added to the phishing dataset
13. Form submission to malicious page - should not be added to phishing dataset
14. Phishing form handler - should be added to phishing dataset
15. Service worker phishing loader - should not be added to phishing dataset