### PR TITLE
Update expected AMP redirection URL

### DIFF
--- a/privacy-protections/amp/index.html
+++ b/privacy-protections/amp/index.html
@@ -24,7 +24,7 @@
     <ul>
       <li>
         <p><a id="link1" href="https://www.google.com/amp/s/www.vox.com/platform/amp/identities/22530103/asians-americans-wealth-income-gap-crazy-rich-model-minority">*Simple link</a></p>
-        <p class="expected">Expected: https://www.vox.com/platform/amp/identities/22530103/asians-americans-wealth-income-gap-crazy-rich-model-minority</p>
+        <p class="expected">Expected: https://www.vox.com/identities/22530103/asians-americans-wealth-income-gap-crazy-rich-model-minority</p>
       </li>
       <li>
         <p><a href="https://www.google.com/amp/s/www.nytimes.com/2021/09/20/business/jeff-bezos-earth-fund.amp.html">*Simple link #2</a></p>


### PR DESCRIPTION
It seems that one of the URLs in the AMP test page is out of date,
let's update that now to get the extension integration tests passing
again.