### PR TITLE
Update all references for [Back] for Security Badware Pages

### DIFF
--- a/security/badware/phishing-form-submission.html
+++ b/security/badware/phishing-form-submission.html
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-    <p><a href="./index.html">[Back]</a></p>
+    <p><a href="/security/badware/">[Back]</a></p>
 
     <h1>Phishing Page Form Submission</h1>
 

--- a/security/badware/phishing-iframe-loader.html
+++ b/security/badware/phishing-iframe-loader.html
@@ -5,7 +5,7 @@
     <title>Phishing page loaded in iframe</title>
 </head>
 <body>
-<p><a href="./index.html">[Back]</a></p>
+<p><a href="/security/badware/">[Back]</a></p>
 
 <h1>Phishing Page iFrame Loader</h1>
 

--- a/security/badware/phishing-iframe-top-navigator-parent.html
+++ b/security/badware/phishing-iframe-top-navigator-parent.html
@@ -10,7 +10,7 @@
     </script>
 </head>
 <body>
-<p><a href="./index.html">[Back]</a></p>
+<p><a href="/security/badware/">[Back]</a></p>
 
 <h1>Phishing Page iFrame Top Navigator Parent</h1>
 

--- a/security/badware/phishing-iframe-top-navigator.html
+++ b/security/badware/phishing-iframe-top-navigator.html
@@ -10,7 +10,7 @@
     </script>
 </head>
 <body>
-<p><a href="./index.html">[Back]</a></p>
+<p><a href="/security/badware/">[Back]</a></p>
 
 <h1>Phishing Page iFrame Top Navigator</h1>
 

--- a/security/badware/phishing-js-redirector-helper.html
+++ b/security/badware/phishing-js-redirector-helper.html
@@ -9,7 +9,7 @@
     </script>
 </head>
 <body>
-<p><a href="./index.html">[Back]</a></p>
+<p><a href="/security/badware/">[Back]</a></p>
 
 <h1>Phishing Page JS Redirects (Direct)</h1>
 

--- a/security/badware/phishing-js-redirector.html
+++ b/security/badware/phishing-js-redirector.html
@@ -9,7 +9,7 @@
     </script>
 </head>
 <body>
-<p><a href="./index.html">[Back]</a></p>
+<p><a href="/security/badware/">[Back]</a></p>
 
 <h1>Phishing Page JS Redirects (Indirect)</h1>
 

--- a/security/badware/phishing-legit-iframe-loader.html
+++ b/security/badware/phishing-legit-iframe-loader.html
@@ -5,7 +5,7 @@
     <title>Phishing page loaded in iframe</title>
 </head>
 <body>
-<p><a href="./index.html">[Back]</a></p>
+<p><a href="/security/badware/">[Back]</a></p>
 
 <h1>Phishing Page - iFrame Spoofing</h1>
 

--- a/security/badware/phishing-meta-redirect-clean.html
+++ b/security/badware/phishing-meta-redirect-clean.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-    <p><a href="./index.html">[Back]</a></p>
+    <p><a href="/security/badware/">[Back]</a></p>
 
     <h1>Phishing Redirect via Meta Refresh</h1>
 

--- a/security/badware/phishing-meta-redirect.html
+++ b/security/badware/phishing-meta-redirect.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-    <p><a href="./index.html">[Back]</a></p>
+    <p><a href="/security/badware/">[Back]</a></p>
 
     <h1>Phishing Redirect via Meta Refresh</h1>
 

--- a/security/badware/phishing-popups.html
+++ b/security/badware/phishing-popups.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-    <p><a href="./index.html">[Back]</a></p>
+    <p><a href="/security/badware/">[Back]</a></p>
 
     <h1>Phishing Page Opener via Popups</h1>
 

--- a/security/badware/phishing-service-worker.html
+++ b/security/badware/phishing-service-worker.html
@@ -44,7 +44,7 @@
 </head>
 
 <body>
-    <p><a href="./index.html">[Back]</a></p>
+    <p><a href="/security/badware/">[Back]</a></p>
 
     <h1>Phishing Page Service Worker</h1>
 

--- a/security/badware/phishing-url-tampering.html
+++ b/security/badware/phishing-url-tampering.html
@@ -42,7 +42,7 @@
   </script>
 </head>
 <body>
-  <p><a href="./index.html">[Back]</a></p>
+  <p><a href="/security/badware/">[Back]</a></p>
 
 <h1>Phishing Opening via URL Tampering</h1>
 

--- a/security/badware/phishing.html
+++ b/security/badware/phishing.html
@@ -5,7 +5,7 @@
   <title>Phishing page</title>
 </head>
 <body>
-  <p><a href="./index.html">[Back]</a></p>
+  <p><a href="/security/badware/">[Back]</a></p>
 
 <h1>Phishing page</h1>
 


### PR DESCRIPTION
Previously we were using ./index.html for the [Back] references, but this would cause the error page to throw again (since the dataset includes badware/*.html. Instead we take it back to /security/badware (no index.html).