### PR TITLE
Fix first-party.site url on the bounce tracking page

### DIFF
--- a/privacy-protections/bounce-tracking/bounce.html
+++ b/privacy-protections/bounce-tracking/bounce.html
@@ -11,7 +11,7 @@
     <textarea id='note' style='width: 500px; height: 200px;' readonly></textarea>
     
     <script>
-        const destinationSafelist = ['privacy-test-pages.site', 'first-party.site', 'good.third-party.site', '127.0.0.1:3000'];
+        const destinationSafelist = ['privacy-test-pages.site', 'www.first-party.site', 'good.third-party.site', '127.0.0.1:3000'];
         const fieldName = 'bounceUID';
         let uid = localStorage.getItem(fieldName);
         const pageURL = new URL(location.href);

--- a/privacy-protections/bounce-tracking/index.html
+++ b/privacy-protections/bounce-tracking/index.html
@@ -13,7 +13,7 @@
     <p>Below links allow to bounce of bad.third-party.site to different locations. bad.third-party.site will pass its local UID to the destination via URL param.</p>
 
     <p><a href='https://bad.third-party.site/privacy-protections/bounce-tracking/bounce.html?destination=good.third-party.site'>Go to good.third-party.site</a></p>
-    <p><a href='https://bad.third-party.site/privacy-protections/bounce-tracking/bounce.html?destination=first-party.site'>Go to first-party.site</a></p>
+    <p><a href='https://bad.third-party.site/privacy-protections/bounce-tracking/bounce.html?destination=www.first-party.site'>Go to first-party.site</a></p>
     <p><a href='https://bad.third-party.site/privacy-protections/bounce-tracking/bounce.html?destination=privacy-test-pages.site'>Go to privacy-test-pages.site</a></p>
     <!--<p><a href='./bounce.html?destination=127.0.0.1:3000'>Bounce local test</a></p>-->
 


### PR DESCRIPTION
apparently first-party.site is not valid, only www.first-party.site works