### PR TITLE
Update C-S-S package to pull in latest webcompat tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
 	<li><a href='./viewport/'>Viewport test cases</a></li>
 	<li><a href='./windows-browser/script-injection/index.html'>Windows Browser: MainWorld Script injection tests</a></li>
 	<li><a href='./windows-browser/script-injection/secureWorld_index.html'>Windows Browser: SecureWorld Script injection tests</a></li>
+	<li><a href='./content-scope-scripts/webcompat/'>Webcompat tests</a></li>
 	<li><a href='./tools/reach-calculator.html'>Site Breakage Reach Calculator</a></li>
 </ul>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@duckduckgo/privacy-test-pages",
       "dependencies": {
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.21.0",
         "body-parser": "^1.20.1",
         "express": "^4.19.2",
         "node-cache": "^5.1.2",
@@ -128,8 +128,9 @@
       }
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#19c304704f1f72a37b64ceec545d051c4042ee3a",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1d5d0573a55286f6634b2579577de6a4d48865ec",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/special-pages",
         "packages/messaging"
@@ -3517,8 +3518,8 @@
       }
     },
     "@duckduckgo/content-scope-scripts": {
-      "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#19c304704f1f72a37b64ceec545d051c4042ee3a",
-      "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts",
+      "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1d5d0573a55286f6634b2579577de6a4d48865ec",
+      "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#6.21.0",
       "requires": {
         "immutable-json-patch": "^5.1.3",
         "parse-address": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/duckduckgo/privacy-test-pages#readme",
   "dependencies": {
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.21.0",
     "body-parser": "^1.20.1",
     "express": "^4.19.2",
     "node-cache": "^5.1.2",


### PR DESCRIPTION
Pretty straightforward changes, just added a tag to the C-S-S package in package.json and added a link from index to the webcompat test page. This will pull in the updated tests from https://github.com/duckduckgo/content-scope-scripts/pull/1026