### PR TITLE
Add Malware Download Test Page

### DIFF
--- a/security/badware/index.html
+++ b/security/badware/index.html
@@ -12,6 +12,7 @@
     <ul>
         <li><a href="./phishing.html">Standard Phishing Test</a></li>
         <li><a href="./malware.html">Standard Malware Test</a></li>
+        <li><a href="./malware-download.html">Malware Download Test</a></li>
         <li><a href="./phishing-iframe-loader.html">Phishing iFrame Loader</a></li>
         <li><a href="./phishing-js-redirector-helper.html">Phishing JS Redirector (Direct)</a></li>
         <li><a href="./phishing-js-redirector.html">Phishing JS Redirector (Indirect)</a></li>

--- a/security/badware/malware-download.html
+++ b/security/badware/malware-download.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Malware download page</title>
+    <script>
+        // eslint-disable-next-line no-unused-vars
+        function run() {
+            const url = "/security/badware/phishing-redirect/download";
+            const link = document.createElement('a');
+            link.href = url;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+    </script>
+</head>
+
+<body>
+    <p><a href="/security/badware/">[Back]</a></p>
+
+    <h1>Malware download page</h1>
+
+    <p>This is an example malware page that DuckDuckGo clients intend to block. If you arrive here by mistake; there's
+        nothing to worry about, we just use this page to test if our client blocking is working.</p>
+
+    <button id="run" onclick="run()">Download</button>
+</body>
+
+</html>

--- a/security/badware/server/routes.js
+++ b/security/badware/server/routes.js
@@ -63,19 +63,18 @@ router.post('/form', (req, res) => {
 
 // Serves an arbitrary executable file to test download detection
 router.get('/download', (req, res) => {
-  // Create a buffer with a minimal valid PE header
-  const fileData = Buffer.alloc(64);
-  // MZ header (magic bytes)
-  const magicBytes = [0x4d, 0x5a];
-  // DOS stub filled with zeros
-  const dosStub = new Uint8Array(58).fill(0);
-  fileData.set(magicBytes, 0);
-  fileData.set(dosStub, 2);
+    // Create a buffer with a minimal valid PE header
+    const fileData = Buffer.alloc(64);
+    // MZ header (magic bytes)
+    const magicBytes = [0x4d, 0x5a];
+    // DOS stub filled with zeros
+    const dosStub = new Uint8Array(58).fill(0);
+    fileData.set(magicBytes, 0);
+    fileData.set(dosStub, 2);
 
-  res.setHeader("Content-Type", "application/octet-stream");
-  res.setHeader("Content-Disposition", 'attachment; filename="test.exe"');
-  res.send(fileData);
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', 'attachment; filename="test.exe"');
+    res.send(fileData);
 });
-
 
 module.exports = router;

--- a/security/badware/server/routes.js
+++ b/security/badware/server/routes.js
@@ -61,4 +61,21 @@ router.post('/form', (req, res) => {
     res.send('Form submitted');
 });
 
+// Serves an arbitrary executable file to test download detection
+router.get('/download', (req, res) => {
+  // Create a buffer with a minimal valid PE header
+  const fileData = Buffer.alloc(64);
+  // MZ header (magic bytes)
+  const magicBytes = [0x4d, 0x5a];
+  // DOS stub filled with zeros
+  const dosStub = new Uint8Array(58).fill(0);
+  fileData.set(magicBytes, 0);
+  fileData.set(dosStub, 2);
+
+  res.setHeader("Content-Type", "application/octet-stream");
+  res.setHeader("Content-Disposition", 'attachment; filename="test.exe"');
+  res.send(fileData);
+});
+
+
 module.exports = router;


### PR DESCRIPTION
Although we're currently not looking to do download protection, there is a possibility that we achieve some level of download protection, if the download URL is in our dataset. 

As such I've created a dummy .exe download test, and added the URL to the backend test pages to see if we can get any quick wins for download protection by proxy of implementing malware URL protection in our navigation handlers.