### PR TITLE
Fix address bar spoofing server routes

### DIFF
--- a/security/address-bar-spoofing/spoof-js-download-url.html
+++ b/security/address-bar-spoofing/spoof-js-download-url.html
@@ -11,7 +11,7 @@
       const w = open()
       w.opener = null
       w.document.write('<h1>Not DDG.</h1>')
-      w.location = '/security/address-bar-spoofing-download-redirect'
+      w.location = '/security/abs/download-redirect'
     }
   </script>
 </head>

--- a/security/address-bar-spoofing/spoof-new-window.html
+++ b/security/address-bar-spoofing/spoof-new-window.html
@@ -19,7 +19,7 @@
                 try {
                     w.location.href;
                 } catch (e) {
-                    w.location.href = 'https://broken.third-party.site/security/address-bar-spoofing/no-content';
+                    w.location.href = 'https://broken.third-party.site/security/abs/no-content';
                     clearInterval(i);
                 }
             }, 1);
@@ -37,7 +37,7 @@
     vulnerable to this attack. Note: this won't work if run from broken.third-party.site. Ensure it is run from 
     another origin such as https://privacy-test-pages.site.
 
-    
+
     <button onclick="newWindow()">New Window</button>
     <button onclick="spoof()">Spoof</button>
 </body>

--- a/server.js
+++ b/server.js
@@ -279,7 +279,7 @@ const viewportRoutes = require('./viewport/server/routes.js');
 app.use('/viewport', viewportRoutes);
 
 const addressBarSpoofingRoutes = require('./security/address-bar-spoofing/server/routes.js');
-app.use('/security/address-bar-spoofing-download-redirect', addressBarSpoofingRoutes);
+app.use('/security/abs/', addressBarSpoofingRoutes);
 
 const phishingDetectionRoutes = require('./security/badware/server/routes.js');
 app.use('/security/badware/phishing-redirect', phishingDetectionRoutes);


### PR DESCRIPTION
There were route collisions in https://github.com/duckduckgo/privacy-test-pages/pull/243 that needed resolving.

Introduce `/security/abs/` for server defined routes so as not to collide with `/security/address-bar-spoofing/` static routes.