### PR TITLE
Malicious site protection edge cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 	<li><a href="./security/csp-report/index.html">Leak of extension IDs via CSP</a></li>
 	<li><a href="./security/js-leaks.html">Detect changes to JS objects in global scope</a></li>
 	<li><a href="./security/popups/popup-launcher.html">Popup noopener/noreferrer tests</a></li>
-	<li><a href="./security/badware/">Phishing Detection Pages</a></li>
+	<li><a href="./security/badware/">Malicious Site Protection Test Pages</a></li>
 </ul>
 
 <h2>Privacy Protections Tests</h2>

--- a/security/badware/index.html
+++ b/security/badware/index.html
@@ -3,27 +3,30 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Test Pages - Phishing Detection</title>
+    <title>Test Pages - Malicious Site Protection</title>
 </head>
 
 <body>
-    <h1>Phishing Detection Test Pages</h1>
+    <h1>Malicious Site Protection Test Pages</h1>
     <a href="/">[Home]</a>
     <ul>
         <li><a href="./phishing.html">Standard Phishing Test</a></li>
         <li><a href="./malware.html">Standard Malware Test</a></li>
-        <li><a href="./malware-download.html">Malware Download Test</a></li>
         <li><a href="./phishing-iframe-loader.html">Phishing iFrame Loader</a></li>
-        <li><a href="./phishing-js-redirector-helper.html">Phishing JS Redirector (Direct)</a></li>
-        <li><a href="./phishing-js-redirector.html">Phishing JS Redirector (Indirect)</a></li>
         <li><a href="./phishing-legit-iframe-loader.html">Phishing Legit iFrame Loader</a></li>
-        <li><a href="./phishing-meta-redirect-clean.html">Phishing Redirect via Meta Refresh (Not Flagged in Dataset)</a></li>
-        <li><a href="./phishing-meta-redirect.html">Phishing Redirect via Meta Refresh (Flagged in Dataset)</a></li>
         <li><a href="./phishing-popups.html">Phishing Open via Popups</a></li>
         <li><a href="./phishing-url-tampering.html">Phishing Opening with URL Tampering</a></li>
         <li><a href="./phishing-form-submission.html">Phishing Form Submission</a></li>
-        <li><a href="./phishing-iframe-top-navigator.html">Phishing iFrame Top Navigator</a></li>
         <li><a href="./phishing-service-worker.html">Phishing Service Worker</a></li>
+        <li><a href="./malware-download.html">Malware Download Test</a></li>
+    </ul>
+
+    <h2>Redirects</h2>
+    <ul>
+        <li><a href="./phishing-meta-redirect-clean.html">Phishing Redirect via Meta Refresh (Not Flagged in Dataset)</a></li>
+        <li><a href="./phishing-meta-redirect.html">Phishing Redirect via Meta Refresh (Flagged in Dataset)</a></li>
+        <li><a href="./phishing-js-redirector-helper.html">Phishing JS Redirector (Direct)</a></li>
+        <li><a href="./phishing-js-redirector.html">Phishing JS Redirector (Indirect)</a></li>
         <li><a href="./phishing-iframe-top-navigator-parent.html">Phishing iFrame Top Navigator Parent</a></li>
         <li><a href="/security/badware/phishing-redirect/">HTTP 301 Redirect to Main Phishing Test Page</a></li>
         <li><a href="/security/badware/phishing-redirect/302">HTTP 302 Redirect to Main Phishing Test Page</a></li>
@@ -33,6 +36,18 @@
         <li><a href="/security/badware/phishing-redirect/iframe2">HTTP Redirect to Phishing Legit iFrame Loader</a></li>
         <li><a href="/security/badware/phishing-redirect/meta">HTTP Redirect to Clean Meta Refresh Redirector</a></li>
         <li><a href="/security/badware/phishing-redirect/meta2">HTTP Redirect to Flagged Meta Refresh Redirector</a></li>
+    </ul>
+
+    <h2>Edge Cases</h2>
+    <ul>
+        <li><a href="http://malware.privacy-test-pages.site/security/badware/malware.html">Page flagged by both DNS protection and in-browser protection</a> (⚠️ different domain)</li>
+        <li><a href="http://broken.privacy-test-pages.site/security/badware/malware.html">Page where malicious site protection is disabled via remote config exception</a> (⚠️ different domain)</li>
+        <li><a href="./local-check.html">Page flagged in the local data (doesn't require API request)</a></li>
+    </ul>
+
+    <h2>Utility</h2>
+    <ul>
+        <li><a href="./phishing-iframe-top-navigator.html">Phishing iFrame Top Navigator</a></li>
     </ul>
 </body>
 

--- a/security/badware/index.html
+++ b/security/badware/index.html
@@ -44,11 +44,6 @@
         <li><a href="https://broken.third-party.site/security/badware/malware.html">Page where malicious site protection is disabled via remote config exception</a> (⚠️ different domain)</li>
         <li><a href="./local-check.html">Page flagged in the local data (doesn't require API request)</a></li>
     </ul>
-
-    <h2>Utility</h2>
-    <ul>
-        <li><a href="./phishing-iframe-top-navigator.html">Phishing iFrame Top Navigator</a></li>
-    </ul>
 </body>
 
 </html>

--- a/security/badware/index.html
+++ b/security/badware/index.html
@@ -41,7 +41,7 @@
     <h2>Edge Cases</h2>
     <ul>
         <li><a href="http://malware.privacy-test-pages.site/security/badware/malware.html">Page flagged by both DNS protection and in-browser protection</a> (⚠️ different domain)</li>
-        <li><a href="http://broken.privacy-test-pages.site/security/badware/malware.html">Page where malicious site protection is disabled via remote config exception</a> (⚠️ different domain)</li>
+        <li><a href="https://broken.third-party.site/security/badware/malware.html">Page where malicious site protection is disabled via remote config exception</a> (⚠️ different domain)</li>
         <li><a href="./local-check.html">Page flagged in the local data (doesn't require API request)</a></li>
     </ul>
 

--- a/security/badware/local-check.html
+++ b/security/badware/local-check.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Local-check malware page</title>
+</head>
+
+<body>
+    <p><a href="/security/badware/">[Back]</a></p>
+
+    <h1>Local check malware page</h1>
+
+    <p>This is an example malware page that DuckDuckGo clients intend to block. If you arrive here by mistake; there's
+        nothing to worry about, we just use this page to test if our client blocking is working.</p>
+
+</body>
+</html>


### PR DESCRIPTION
I bundled couple of small changes:
- renamed "phishing detection" to "malicious site protection" to cover both phishing and malware and follow latest naming of this feature
- reorganized order of malicious site protection test pages on the index page for easier reading
- added three edge-case's: when site is in the local cache and doesn't require API request, when site is flagged by both DNS protection and malicious site protection, when site is excluded from protection via remote config exception