### PR TITLE
Add malware href link to malware download test

### DIFF
--- a/security/badware/malware-download.html
+++ b/security/badware/malware-download.html
@@ -25,7 +25,8 @@
     <p>This is an example malware page that DuckDuckGo clients intend to block. If you arrive here by mistake; there's
         nothing to worry about, we just use this page to test if our client blocking is working.</p>
 
-    <button id="run" onclick="run()">Download</button>
+    <button id="run" onclick="run()">Download Button</button>
+    <a href="/security/badware/phishing-redirect/download">Download Link</a>
 </body>
 
 </html>


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1209139335185240/f

Currently we only have the JS malware download test which is sufficient for testing the current working malware protection, but we also need a href download so we can test the flow of "right click">"download file as", to determine what gaps we have in malware download protection.