### PR TITLE
[Autofill] Test pages for partial form saves

### DIFF
--- a/autofill/partialFormSaves/multistep-login.html
+++ b/autofill/partialFormSaves/multistep-login.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Multi-step Login Form</title>
+    <link rel="stylesheet" href="../style.css" />
+</head>
+<body>
+    <p><a href="../index.html#autofill">[Home]</a></p>
+
+    <div class="dialog">
+        <h2>Multi-step Login Form</h2>
+        <p>Enter your email first, then password on the next step</p>
+        
+        <form id="login-form" action="/login">
+            <div id="login-step-1">
+                <fieldset>
+                    <label for="login-email">Email</label>
+                    <input id="login-email" type="email" autocomplete="username" required>
+                    <button type="button" onclick="showStep2()">Next</button>
+                </fieldset>
+            </div>
+            <div id="login-step-2" hidden>
+                <fieldset>
+                    <label for="login-password">Password</label>
+                    <input id="login-password" type="password" autocomplete="current-password" required>
+                    <button type="submit">Log in</button>
+                </fieldset>
+            </div>
+        </form>
+    </div>
+
+    <script>
+        function showStep2() {
+            if (document.getElementById('login-email').checkValidity()) {
+                document.getElementById('login-step-1').remove();
+                document.getElementById('login-step-2').hidden = false;
+            }
+        }
+
+        document.getElementById('login-form').addEventListener('submit', (e) => {
+            e.preventDefault();
+            if (e.target.checkValidity()) {
+                e.target.innerHTML = '<h3>Successfully logged in!</h3>';
+            }
+        });
+    </script>
+</body>
+</html> 

--- a/autofill/partialFormSaves/multistep-signup-confirm.html
+++ b/autofill/partialFormSaves/multistep-signup-confirm.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Multi-step Signup with Confirmation</title>
+    <link rel="stylesheet" href="../style.css" />
+</head>
+<body>
+    <p><a href="../index.html#autofill">[Home]</a></p>
+
+    <div class="dialog">
+        <h2>Multi-step Signup with Password Confirmation</h2>
+        <p>Create account: email first, then set and confirm password</p>
+        
+        <form id="signup-form" action="/signup">
+            <div id="signup-step-1">
+                <fieldset>
+                    <label for="signup-email">Email</label>
+                    <input id="signup-email" type="email" autocomplete="username" required>
+                    <button type="button" onclick="showStep2()">Continue</button>
+                </fieldset>
+            </div>
+            <div id="signup-step-2" hidden>
+                <fieldset>
+                    <label for="signup-password">Password</label>
+                    <input id="signup-password" type="password" autocomplete="new-password" required>
+                    <label for="signup-password-confirm">Confirm Password</label>
+                    <input id="signup-password-confirm" type="password" autocomplete="new-password" required>
+                    <button type="submit">Create Account</button>
+                </fieldset>
+            </div>
+        </form>
+    </div>
+
+    <script>
+        function showStep2() {
+            if (document.getElementById('signup-email').checkValidity()) {
+                document.getElementById('signup-step-1').remove();
+                document.getElementById('signup-step-2').hidden = false;
+            }
+        }
+
+        document.getElementById('signup-form').addEventListener('submit', (e) => {
+            e.preventDefault();
+            const password1 = document.getElementById('signup-password').value;
+            const password2 = document.getElementById('signup-password-confirm').value;
+            
+            if (e.target.checkValidity() && password1 === password2) {
+                e.target.innerHTML = '<h3>Account created successfully!</h3>';
+            } else if (password1 !== password2) {
+                alert('Passwords do not match');
+            }
+        });
+    </script>
+</body>
+</html> 

--- a/autofill/partialFormSaves/multistep-signup.html
+++ b/autofill/partialFormSaves/multistep-signup.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Multi-step Signup Form</title>
+    <link rel="stylesheet" href="../style.css" />
+</head>
+<body>
+    <p><a href="../index.html#autofill">[Home]</a></p>
+
+    <div class="dialog">
+        <h2>Multi-step Signup Form</h2>
+        <p>Create account: email first, then set password</p>
+        
+        <form id="signup-form" action="/signup">
+            <div id="signup-step-1">
+                <fieldset>
+                    <label for="signup-email">Email</label>
+                    <input id="signup-email" type="email" autocomplete="username" required>
+                    <button type="button" onclick="showStep2()">Continue</button>
+                </fieldset>
+            </div>
+            <div id="signup-step-2" hidden>
+                <fieldset>
+                    <label for="signup-password">Password</label>
+                    <input id="signup-password" type="password" autocomplete="new-password" required>
+                    <button type="submit">Create Account</button>
+                </fieldset>
+            </div>
+        </form>
+    </div>
+
+    <script>
+        function showStep2() {
+            if (document.getElementById('signup-email').checkValidity()) {
+                document.getElementById('signup-step-1').remove();
+                document.getElementById('signup-step-2').hidden = false;
+            }
+        }
+
+        document.getElementById('signup-form').addEventListener('submit', (e) => {
+            e.preventDefault();
+            if (e.target.checkValidity()) {
+                e.target.innerHTML = '<h3>Account created successfully!</h3>';
+            }
+        });
+    </script>
+</body>
+</html> 

--- a/autofill/partialFormSaves/password-reset-flow.html
+++ b/autofill/partialFormSaves/password-reset-flow.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Password Reset Flow</title>
+    <link rel="stylesheet" href="../style.css" />
+</head>
+<body>
+    <p><a href="../index.html#autofill">[Home]</a></p>
+
+    <div class="dialog">
+        <h2>Password Reset Flow</h2>
+        <p>First enter your username</p>
+        
+        <form id="reset-form-step1" action="/reset-password">
+            <div id="reset-step-1">
+                <fieldset>
+                    <label for="reset-username">Username</label>
+                    <input id="reset-username" type="text" autocomplete="username" required>
+                    <button type="button" onclick="showResetForm()">Send reset email</button>
+                </fieldset>
+            </div>
+        </form>
+
+        <!-- Separate form for new password -->
+        <form id="reset-form-step2" action="/reset-password-complete" hidden>
+            <div id="reset-step-2">
+                <fieldset>
+                    <label for="reset-new-password">New Password</label>
+                    <input id="reset-new-password" type="password" autocomplete="new-password" required>
+                    <button type="submit">Reset Password</button>
+                </fieldset>
+            </div>
+        </form>
+    </div>
+
+    <script>
+        function showResetForm() {
+            if (document.getElementById('reset-username').checkValidity()) {
+                document.getElementById('reset-form-step1').remove();
+                document.getElementById('reset-form-step2').hidden = false;
+            }
+        }
+
+        document.getElementById('reset-form-step2').addEventListener('submit', (e) => {
+            e.preventDefault();
+            if (e.target.checkValidity()) {
+                e.target.innerHTML = '<h3>Password reset successfully!</h3>';
+            }
+        });
+    </script>
+</body>
+</html> 

--- a/index.html
+++ b/index.html
@@ -110,6 +110,13 @@
 	    <li><a href="./autofill/autoprompt/4-covered-form.html">With dialog covering the form</a></li>
 	    <li><a href="./autofill/autoprompt/5-form-with-text.html">Form below the fold on mobile but in sidebar on larger screens</a></li>
 		</ul>
+		Multi-step test forms for partial form saves
+		<ul>
+			<li><a href="./autofill/partialFormSaves/multistep-login.html">Multistep login form</a></li>
+			<li><a href="./autofill/partialFormSaves/multistep-signup.html">Multistep signup form</a></li>
+			<li><a href="./autofill/partialFormSaves/multistep-signup-confirm.html">Multistep signup form with password confirmation</a></li>
+			<li><a href="./autofill/partialFormSaves/password-reset-flow.html">Password reset flow</a></li>
+		</ul>
 	</li>
 </ul>
 


### PR DESCRIPTION
Adding test pages to simplify Ship Review and testing of [Increase ratio of complete form saves](https://app.asana.com/0/72649045549333/1206048666874230/f) project.

We have seen that communicating the testing scenarios (e.g during a Ship Review) has been very difficult. Having specific pages will greatly help here.

Example password-reset with and without `partialFormSaves`:

https://github.com/user-attachments/assets/05961137-ac58-4f4f-bf2a-a5d60ecf5dc6

