### PR TITLE
Add uncommon URL escape sequence test page

### DIFF
--- a/security/badware/index.html
+++ b/security/badware/index.html
@@ -40,6 +40,7 @@
 
     <h2>Edge Cases</h2>
     <ul>
+        <li><a href="./phishing badͮ.html">Phishing Page With Abnormal URL Escape Sequences</a></li>
         <li><a href="http://malware.privacy-test-pages.site/security/badware/malware.html">Page flagged by both DNS protection and in-browser protection</a> (⚠️ different domain)</li>
         <li><a href="https://broken.third-party.site/security/badware/malware.html">Page where malicious site protection is disabled via remote config exception</a> (⚠️ different domain)</li>
         <li><a href="./local-check.html">Page flagged in the local data (doesn't require API request)</a></li>

--- a/security/badware/phishing badͮ.html
+++ b/security/badware/phishing badͮ.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Phishing page</title>
+</head>
+<body>
+  <p><a href="/security/badware/">[Back]</a></p>
+
+<h1>Phishing page</h1>
+
+<p>This is an example phishing page that DuckDuckGo clients intend to block. The URL here uses uncommon escape sequences for UTF-16 characters to test how our browsers protect against them. If you arrive here by mistake; there's nothing to worry about, we just use this page to test if our client blocking is working.</p>
+
+</body>
+</html>


### PR DESCRIPTION
We discovered that certain escape sequences may break our protections. After discussing with Netcraft, they confirmed that they make no attempt to URL decode before building regular expressions. Therefore, all URL encoding should be taken as is by the clients.

This PR introduces one such phishing sample page.