### PR TITLE
Add delayed redirect route to address bar spoofing test fixtures

### DIFF
--- a/security/address-bar-spoofing/index.html
+++ b/security/address-bar-spoofing/index.html
@@ -21,6 +21,7 @@
         <li><a href="/security/address-bar-spoofing/js-page-rewrite.html">Long Loading Request Rewrite</a></li>
         <li><a href="/security/address-bar-spoofing/spoof-new-window.html">New Window Rewrite</a></li>
         <li><a href="/security/address-bar-spoofing/spoof-about-blank-emptyaddress.html">About:Blank Empty Address Spoof</a></li>
+        <li><a href="/security/abs/redirect?target=/&delay=2000">Delayed Redirect (2s)</a></li>
     </ul>
   </body>
 </html>

--- a/security/address-bar-spoofing/server/routes.js
+++ b/security/address-bar-spoofing/server/routes.js
@@ -21,7 +21,8 @@ router.get('/redirect', (req, res) => {
     }
 
     const delay = parseInt(req.query.delay);
-    const status = parseInt(req.query.status) || 302;
+    const parsedStatus = parseInt(req.query.status);
+    const status = parsedStatus >= 100 && parsedStatus <= 999 ? parsedStatus : 302;
 
     if (delay && !isNaN(delay)) {
         if (delay > 5000) {

--- a/security/address-bar-spoofing/server/routes.js
+++ b/security/address-bar-spoofing/server/routes.js
@@ -12,4 +12,27 @@ router.get('/no-content', (req, res) => {
     res.status(204).send();
 });
 
+// Returns a redirect to the given target URL, with optional delay (ms) and status code.
+// Example: /redirect?target=https://example.com&delay=2000&status=301
+router.get('/redirect', (req, res) => {
+    const target = req.query.target;
+    if (!target) {
+        return res.status(400).send('Missing required "target" query parameter');
+    }
+
+    const delay = parseInt(req.query.delay);
+    const status = parseInt(req.query.status) || 302;
+
+    if (delay && !isNaN(delay)) {
+        if (delay > 5000) {
+            return res.status(400).send('Delay too long');
+        }
+        setTimeout(() => {
+            res.redirect(status, target);
+        }, delay);
+    } else {
+        res.redirect(status, target);
+    }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary

  - Add a configurable redirect route to the address bar spoofing test fixtures
  - Route supports optional `delay` (ms) and `status` code query parameters
  - Add link to the address bar spoofing index page

  ## New route

  `GET /security/abs/redirect?target=<url>&delay=<ms>&status=<code>`

  - `target` (required): URL to redirect to
  - `delay` (optional): milliseconds to wait before redirecting (max 5000)
  - `status` (optional): HTTP status code, defaults to 302

  ## Usage

  This enables testing address bar behavior during server redirect chains. The delay parameter allows automated tests (e.g., Maestro) to assert on address bar state
  mid-redirect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-fixture-only changes adding a small Express route and a static link; minimal blast radius and no secrets introduced.
> 
> **Overview**
> Adds a new `GET /security/abs/redirect` fixture route that redirects to a required `target` URL, optionally delaying the redirect (capped at 5s) and allowing a custom HTTP status (default `302`).
> 
> Updates the address-bar spoofing `index.html` to include a convenient “Delayed Redirect (2s)” link for exercising mid-redirect address bar behavior in tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb8cfc984c8b137c8df4e91c9691b767d7c462ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->