### PR TITLE
Update redirect chain structure for origin based address bar filtering tests in iOS

### DIFF
--- a/security/address-bar-spoofing/index.html
+++ b/security/address-bar-spoofing/index.html
@@ -21,7 +21,7 @@
         <li><a href="/security/address-bar-spoofing/js-page-rewrite.html">Long Loading Request Rewrite</a></li>
         <li><a href="/security/address-bar-spoofing/spoof-new-window.html">New Window Rewrite</a></li>
         <li><a href="/security/address-bar-spoofing/spoof-about-blank-emptyaddress.html">About:Blank Empty Address Spoof</a></li>
-        <li><a href="/security/abs/redirect?target=/&delay=2000">Delayed Redirect (2s)</a></li>
+        <li><a href="/security/abs/redirect?target=https%3A%2F%2Fwww.first-party.site%2Fsecurity%2Fabs%2Fredirect%3Ftarget%3Dhttps%3A%2F%2Fprivacy-test-pages.site%2Fsecurity%2Faddress-bar-spoofing%2Findex.html%26delay%3D3000">Redirect Chain (cross-origin, 3s delay)</a></li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
Follow up for #421 to enable some iOS Maestro UI tests that require no direct user interaction (e.g. explicit address bar navigation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single test-page link is updated to use a longer cross-origin redirect chain, with no production logic changes.
> 
> **Overview**
> Updates `security/address-bar-spoofing/index.html` to replace the old delayed-redirect entry with a **cross-origin redirect chain** link that encodes nested `target` URLs and a 3s delay, aligning address-bar filtering tests with the desired origin-based redirect behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cd65e645535cc4237e41587a4eca4e15e135d60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->