### PR TITLE
Add ICS calendar download fixtures

### DIFF
--- a/features/download/calendar-malformed.ics
+++ b/features/download/calendar-malformed.ics
@@ -1,0 +1,10 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//DuckDuckGo//Privacy Test Pages//EN
+BEGIN:VEVENT
+UID:malformed@privacy-test-pages.site
+DTSTAMP:20260513T120000Z
+DTSTART:not-a-real-date
+SUMMARY:Malformed DTSTART
+END:VEVENT
+END:VCALENDAR

--- a/features/download/calendar-multi.ics
+++ b/features/download/calendar-multi.ics
@@ -1,0 +1,22 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//DuckDuckGo//Privacy Test Pages//EN
+BEGIN:VEVENT
+UID:multi-first@privacy-test-pages.site
+DTSTAMP:20260513T120000Z
+DTSTART:20260601T140000Z
+DTEND:20260601T150000Z
+SUMMARY:First Test Event
+DESCRIPTION:First of two events. Used to verify multi-VEVENT fallback behaviour.
+LOCATION:Privacy Test Pages
+END:VEVENT
+BEGIN:VEVENT
+UID:multi-second@privacy-test-pages.site
+DTSTAMP:20260513T120000Z
+DTSTART:20260602T140000Z
+DTEND:20260602T150000Z
+SUMMARY:Second Test Event
+DESCRIPTION:Second of two events.
+LOCATION:Privacy Test Pages
+END:VEVENT
+END:VCALENDAR

--- a/features/download/calendar-single.ics
+++ b/features/download/calendar-single.ics
@@ -1,0 +1,13 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//DuckDuckGo//Privacy Test Pages//EN
+BEGIN:VEVENT
+UID:single-event@privacy-test-pages.site
+DTSTAMP:20260513T120000Z
+DTSTART:20260601T140000Z
+DTEND:20260601T150000Z
+SUMMARY:Privacy Test Pages — Single Event
+DESCRIPTION:Test fixture used to verify .ics download handling. Tap "Add" to add it to your calendar; tap "Cancel" to discard.
+LOCATION:Privacy Test Pages
+END:VEVENT
+END:VCALENDAR

--- a/features/download/calendar-unrecognized-timezone.ics
+++ b/features/download/calendar-unrecognized-timezone.ics
@@ -1,0 +1,11 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//DuckDuckGo//Privacy Test Pages//EN
+BEGIN:VEVENT
+UID:unrecognized-tz@privacy-test-pages.site
+DTSTAMP:20260513T120000Z
+DTSTART;TZID=Definitely Not A Real Timezone:20260601T140000
+DTEND;TZID=Definitely Not A Real Timezone:20260601T150000
+SUMMARY:Unrecognized Time Zone
+END:VEVENT
+END:VCALENDAR

--- a/features/download/index.html
+++ b/features/download/index.html
@@ -16,6 +16,14 @@
   <li><a href="download.pdf" download>Download PDF</a>
 </ul>
 
+<p>Download iCalendar (.ics)</p>
+<ul>
+  <li><a href="calendar-single.ics">Single-event .ics (text/calendar)</a>
+  <li><a href="calendar-multi.ics">Multi-event .ics (text/calendar)</a>
+  <li><a href="calendar-malformed.ics">Malformed .ics (broken DTSTART)</a>
+  <li><a href="calendar-unrecognized-timezone.ics">Unrecognized time zone .ics</a>
+</ul>
+
 <p>Dynamic download (data URL)</p>
 <ul>
   <li><a href="download-csv.html">Programmatic CSV download from anchor click</a>


### PR DESCRIPTION
This PR adds some ICS calendar fixtures for iOS Maestro download tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds static test fixture files and links on the download test page, with no runtime logic changes beyond exposing new assets.
> 
> **Overview**
> Adds four new `.ics` calendar download fixtures to the `features/download` test pages: a single event, a multi-`VEVENT` file, a malformed `DTSTART`, and an unrecognized timezone case.
> 
> Updates `features/download/index.html` to surface these fixtures via a new “Download iCalendar (.ics)” section with direct links for use in automated download handling tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957a0b85a4f9d21713a0129b5c2091798c10664e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->