### PR TITLE
Add device enumeration test page

### DIFF
--- a/features/device-enumeration-chaos/iframe-child.html
+++ b/features/device-enumeration-chaos/iframe-child.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Chaos iframe child</title>
+</head>
+<body>
+    <p>Chaos iframe child. Awaits postMessage from parent.</p>
+    <script>
+        const RUNNERS = {
+            async A1() {
+                const devices = await navigator.mediaDevices.enumerateDevices();
+                return { count: devices.length, kinds: devices.map((d) => d.kind) };
+            },
+            async B1() {
+                const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+                const tracks = stream.getTracks().map((t) => ({ kind: t.kind, label: t.label }));
+                for (const t of stream.getTracks()) t.stop();
+                return { tracks };
+            },
+        };
+
+        window.addEventListener('message', async (event) => {
+            const data = event.data || {};
+            if (data.type !== 'chaos-run') return;
+
+            const { requestId, technique } = data;
+            const runner = RUNNERS[technique];
+            const started = performance.now();
+            let response;
+            if (!runner) {
+                response = { error: 'unknown-technique' };
+            } else {
+                try {
+                    const value = await runner();
+                    response = { value };
+                } catch (err) {
+                    response = { error: err && (err.name || err.message) ? `${err.name || ''}: ${err.message || err}` : String(err) };
+                }
+            }
+            response.durationMs = Math.round(performance.now() - started);
+
+            event.source.postMessage(
+                { type: 'chaos-result', requestId, response },
+                event.origin === 'null' ? '*' : event.origin,
+            );
+        });
+
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage({ type: 'chaos-iframe-ready' }, '*');
+        }
+    </script>
+</body>
+</html>

--- a/features/device-enumeration-chaos/index.html
+++ b/features/device-enumeration-chaos/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Device Enumeration Chaos</title>
+    <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+    <p><a href="../../index.html">[Home]</a></p>
+
+    <h1>Device Enumeration Chaos</h1>
+
+    <div class="banner">
+        <h2>What is this page?</h2>
+        <p>
+            Repro tool for the Windows OS camera prompt issue tracked in
+            <a href="https://app.asana.com/1/137249556945/project/949243614371883/task/1213972428315171?focus=true">OPS-7378</a>
+            (camera prompt on signing into claude.ai / linkedin.com / youtube.com). The
+            <code>content-scope-scripts</code> <code>deviceEnumerationFix</code> only intercepts
+            <code>MediaDevices.enumerateDevices()</code>; this page also exercises every adjacent API
+            (<code>getUserMedia</code>, <code>permissions.query</code>, <code>RTCPeerConnection</code>,
+            <code>getDisplayMedia</code>, iframe contexts) so a tester can isolate exactly which call still
+            triggers the OS prompt on a build under test.
+        </p>
+        <p>
+            <strong>How to use it.</strong> On a fresh Windows install where camera permission has never been
+            granted or denied for the DuckDuckGo app, run each technique one at a time, watch for the native
+            OS camera prompt, and use the "OS prompt?" dropdown next to each row to record what you observed.
+            When done, hit <em>Download results</em> to export a JSON record.
+        </p>
+        <p>
+            Note: the <em>B group</em> calls <code>getUserMedia</code> directly and so will legitimately surface a camera/mic prompt on any browser. The question for this repro is whether
+            those calls surface the <em>native Windows OS prompt</em> in addition to or instead of the
+            in-app permission UI.
+        </p>
+    </div>
+
+    <div class="diagnostic">
+        <strong>Runtime diagnostics</strong>
+        <dl id="diagnostic-list"></dl>
+    </div>
+
+    <div class="unleash-bar">
+        <button id="unleash" type="button">Unleash chaos (run everything)</button>
+        <span id="unleash-progress" class="unleash-progress"></span>
+        <span style="flex:1"></span>
+        <label for="overall-prompt">
+            Did the OS prompt appear at any point during the run?
+            <select id="overall-prompt">
+                <option value="not-answered">not answered</option>
+                <option value="yes">Yes — at some point</option>
+                <option value="no">No prompt at any point</option>
+                <option value="in-browser-only">In-browser prompt only</option>
+                <option value="already-granted">Already granted before run</option>
+                <option value="already-denied">Already denied before run</option>
+            </select>
+        </label>
+    </div>
+
+    <div id="techniques"></div>
+
+    <div class="results-bar">
+        <button id="download" type="button">Download results JSON</button>
+        <button id="reset" type="button">Reset state</button>
+    </div>
+
+    <h2>Log</h2>
+    <pre id="log" class="log-panel"></pre>
+
+    <dialog id="confirm-dialog">
+        <h3>Unleash chaos?</h3>
+        <p>
+            This will run all device-enumeration techniques in sequence. The B group calls
+            <code>getUserMedia</code> directly, which will trigger camera/mic permission prompts.
+            Do not run this on a build where you do not want to be prompted.
+        </p>
+        <div class="dialog-actions">
+            <button id="confirm-cancel" type="button">Cancel</button>
+            <button id="confirm-go" type="button" class="danger">Run chaos</button>
+        </div>
+    </dialog>
+
+    <script src="./main.js"></script>
+</body>
+</html>

--- a/features/device-enumeration-chaos/main.js
+++ b/features/device-enumeration-chaos/main.js
@@ -233,20 +233,21 @@ const TECHNIQUES = [
         group: 'A',
         title: 'enumerateDevices() x10 from setInterval / 100ms',
         code: 'setInterval(() => enumerateDevices(), 100) x10',
-        run() {
-            return new Promise((resolve, reject) => {
-                let iterations = 0;
-                const errors = [];
+        async run() {
+            const pending = await new Promise((resolve) => {
+                const promises = [];
                 const id = setInterval(() => {
-                    iterations++;
-                    navigator.mediaDevices.enumerateDevices().catch((e) => errors.push(describeError(e)));
-                    if (iterations >= 10) {
+                    promises.push(navigator.mediaDevices.enumerateDevices());
+                    if (promises.length >= 10) {
                         clearInterval(id);
-                        if (errors.length) reject(new Error(errors.join(' | ')));
-                        else resolve({ iterations });
+                        resolve(promises);
                     }
                 }, 100);
             });
+            const settled = await Promise.allSettled(pending);
+            const errors = settled.filter((s) => s.status === 'rejected').map((s) => describeError(s.reason));
+            if (errors.length) throw new Error(errors.join(' | '));
+            return { iterations: settled.length };
         },
     },
     {

--- a/features/device-enumeration-chaos/main.js
+++ b/features/device-enumeration-chaos/main.js
@@ -112,8 +112,8 @@ function waitForFrameReady(iframe) {
 async function makeIframeFromSrc(extraAttrs = {}) {
     const iframe = document.createElement('iframe');
     iframe.setAttribute('allow', 'camera; microphone');
-    for (const [k, v] of Object.entries(extraAttrs)) iframe.setAttribute(k, v);
     iframe.style.cssText = 'width:320px;height:80px;border:1px dashed #aaa;margin:4px';
+    for (const [k, v] of Object.entries(extraAttrs)) iframe.setAttribute(k, v);
     iframe.src = IFRAME_CHILD_URL;
     document.body.appendChild(iframe);
     await waitForFrameReady(iframe);

--- a/features/device-enumeration-chaos/main.js
+++ b/features/device-enumeration-chaos/main.js
@@ -1,0 +1,871 @@
+/*
+ * Device enumeration chaos test page.
+ *
+ * Repro tool for OPS-7378: the Windows browser (MSIX) is showing the OS
+ * camera permission prompt on sites that silently probe media-device APIs
+ * (claude.ai, linkedin.com, youtube.com). The C-S-S deviceEnumerationFix
+ * only intercepts enumerateDevices(); this page also exercises every
+ * adjacent API (getUserMedia, permissions.query, RTCPeerConnection,
+ * getDisplayMedia, iframe contexts) so a tester can isolate which call
+ * still triggers the OS prompt on a build under test.
+ */
+
+const IFRAME_CHILD_URL = new URL('./iframe-child.html', window.location.href).href;
+const IFRAME_RESPONSE_TIMEOUT_MS = 8000;
+
+const logEl = document.getElementById('log');
+const techniquesEl = document.getElementById('techniques');
+const unleashButton = document.getElementById('unleash');
+const unleashProgress = document.getElementById('unleash-progress');
+const overallPromptSelect = document.getElementById('overall-prompt');
+const downloadButton = document.getElementById('download');
+const resetButton = document.getElementById('reset');
+const confirmDialog = document.getElementById('confirm-dialog');
+const confirmGoButton = document.getElementById('confirm-go');
+const confirmCancelButton = document.getElementById('confirm-cancel');
+
+const state = {
+    startedAt: new Date().toISOString(),
+    userAgent: navigator.userAgent,
+    diagnostics: collectDiagnostics(),
+    overallPromptObserved: 'not-answered',
+    results: {},
+};
+
+function log(message, detail) {
+    const ts = new Date().toISOString();
+    const detailStr = detail === undefined ? '' : ` ${typeof detail === 'string' ? detail : JSON.stringify(detail)}`;
+    logEl.textContent = `${logEl.textContent}[${ts}] ${message}${detailStr}\n`;
+    logEl.scrollTop = logEl.scrollHeight;
+}
+
+function describeError(err) {
+    if (err == null) return 'unknown';
+    if (err instanceof Error) return `${err.name}: ${err.message}`;
+    return String(err);
+}
+
+async function stopStreamTracks(stream) {
+    if (!stream || typeof stream.getTracks !== 'function') return [];
+    const tracks = stream.getTracks();
+    const summary = tracks.map((t) => ({ kind: t.kind, label: t.label, readyState: t.readyState }));
+    for (const track of tracks) {
+        try {
+            track.stop();
+        } catch (e) {
+            // ignore
+        }
+    }
+    return summary;
+}
+
+function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function collectDiagnostics() {
+    const md = navigator.mediaDevices;
+    const enumerateFnSource = md && md.enumerateDevices ? Function.prototype.toString.call(md.enumerateDevices) : null;
+    const getUserMediaFnSource = md && md.getUserMedia ? Function.prototype.toString.call(md.getUserMedia) : null;
+    return {
+        hasMediaDevices: Boolean(md),
+        hasEnumerateDevices: Boolean(md && md.enumerateDevices),
+        hasGetUserMedia: Boolean(md && md.getUserMedia),
+        hasGetDisplayMedia: Boolean(md && md.getDisplayMedia),
+        hasLegacyGetUserMedia: typeof navigator.getUserMedia === 'function',
+        hasPermissionsApi: Boolean(navigator.permissions && navigator.permissions.query),
+        hasRTCPeerConnection: typeof window.RTCPeerConnection === 'function',
+        crossOriginIsolated: Boolean(window.crossOriginIsolated),
+        isSecureContext: Boolean(window.isSecureContext),
+        enumerateDevicesAppearsNative: enumerateFnSource ? /\[native code\]/.test(enumerateFnSource) : null,
+        getUserMediaAppearsNative: getUserMediaFnSource ? /\[native code\]/.test(getUserMediaFnSource) : null,
+        enumerateDevicesSourcePrefix: enumerateFnSource ? enumerateFnSource.slice(0, 200) : null,
+    };
+}
+
+/*
+ * Iframe helpers (Group E).
+ *
+ * Each factory returns a Promise<HTMLIFrameElement> for an iframe that has
+ * loaded iframe-child.html and posted its `chaos-iframe-ready` handshake.
+ * The caller must remove the iframe after use.
+ */
+
+function waitForFrameReady(iframe) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            window.removeEventListener('message', onMessage);
+            reject(new Error('iframe-ready-timeout'));
+        }, IFRAME_RESPONSE_TIMEOUT_MS);
+
+        function onMessage(event) {
+            if (event.source !== iframe.contentWindow) return;
+            if (!event.data || event.data.type !== 'chaos-iframe-ready') return;
+            clearTimeout(timer);
+            window.removeEventListener('message', onMessage);
+            resolve(iframe);
+        }
+        window.addEventListener('message', onMessage);
+    });
+}
+
+async function makeIframeFromSrc(extraAttrs = {}) {
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('allow', 'camera; microphone');
+    for (const [k, v] of Object.entries(extraAttrs)) iframe.setAttribute(k, v);
+    iframe.style.cssText = 'width:320px;height:80px;border:1px dashed #aaa;margin:4px';
+    iframe.src = IFRAME_CHILD_URL;
+    document.body.appendChild(iframe);
+    await waitForFrameReady(iframe);
+    return iframe;
+}
+
+async function makeIframeSrcdoc(srcdocBody) {
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('allow', 'camera; microphone');
+    iframe.style.cssText = 'width:320px;height:80px;border:1px dashed #aaa;margin:4px';
+    iframe.srcdoc = srcdocBody;
+    document.body.appendChild(iframe);
+    await waitForFrameReady(iframe);
+    return iframe;
+}
+
+async function makeIframeDocumentWrite() {
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('allow', 'camera; microphone');
+    iframe.style.cssText = 'width:320px;height:80px;border:1px dashed #aaa;margin:4px';
+    document.body.appendChild(iframe);
+    const doc = iframe.contentDocument;
+    const res = await fetch(IFRAME_CHILD_URL);
+    const html = await res.text();
+    doc.open();
+    doc.write(html);
+    doc.close();
+    await waitForFrameReady(iframe);
+    return iframe;
+}
+
+function sendChaosToFrame(iframe, technique) {
+    return new Promise((resolve, reject) => {
+        const requestId = `req-${Math.random().toString(36).slice(2)}`;
+        const timer = setTimeout(() => {
+            window.removeEventListener('message', onMessage);
+            reject(new Error('iframe-response-timeout'));
+        }, IFRAME_RESPONSE_TIMEOUT_MS);
+
+        function onMessage(event) {
+            if (event.source !== iframe.contentWindow) return;
+            const data = event.data || {};
+            if (data.type !== 'chaos-result' || data.requestId !== requestId) return;
+            clearTimeout(timer);
+            window.removeEventListener('message', onMessage);
+            if (data.response && data.response.error) {
+                reject(new Error(data.response.error));
+            } else {
+                resolve(data.response && data.response.value);
+            }
+        }
+        window.addEventListener('message', onMessage);
+        iframe.contentWindow.postMessage({ type: 'chaos-run', requestId, technique }, '*');
+    });
+}
+
+/*
+ * Chaos technique catalogue.
+ *
+ * Each technique runs exactly one mode of triggering a media-device API.
+ * Keep run() side-effects bounded: stop any tracks, close any peer
+ * connections, and remove any created iframes before returning.
+ */
+
+const TECHNIQUES = [
+    // Group A — enumerateDevices() variants
+    {
+        id: 'A1',
+        group: 'A',
+        title: 'enumerateDevices() — single call',
+        code: 'navigator.mediaDevices.enumerateDevices()',
+        async run() {
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            return { count: devices.length, kinds: devices.map((d) => d.kind) };
+        },
+    },
+    {
+        id: 'A2',
+        group: 'A',
+        title: 'enumerateDevices() x50 sequential',
+        code: 'for (50) await enumerateDevices()',
+        async run() {
+            let last = 0;
+            for (let i = 0; i < 50; i++) {
+                last = (await navigator.mediaDevices.enumerateDevices()).length;
+            }
+            return { iterations: 50, lastCount: last };
+        },
+    },
+    {
+        id: 'A3',
+        group: 'A',
+        title: 'enumerateDevices() x50 parallel (Promise.all)',
+        code: 'Promise.all([enumerateDevices() * 50])',
+        async run() {
+            const results = await Promise.all(Array.from({ length: 50 }, () => navigator.mediaDevices.enumerateDevices()));
+            return { iterations: 50, lastCount: results[results.length - 1].length };
+        },
+    },
+    {
+        id: 'A4',
+        group: 'A',
+        title: 'enumerateDevices() from setTimeout(0)',
+        code: 'setTimeout(() => enumerateDevices(), 0)',
+        run() {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    navigator.mediaDevices.enumerateDevices()
+                        .then((d) => resolve({ count: d.length }))
+                        .catch(reject);
+                }, 0);
+            });
+        },
+    },
+    {
+        id: 'A5',
+        group: 'A',
+        title: 'enumerateDevices() x10 from setInterval / 100ms',
+        code: 'setInterval(() => enumerateDevices(), 100) x10',
+        run() {
+            return new Promise((resolve, reject) => {
+                let iterations = 0;
+                const errors = [];
+                const id = setInterval(() => {
+                    iterations++;
+                    navigator.mediaDevices.enumerateDevices().catch((e) => errors.push(describeError(e)));
+                    if (iterations >= 10) {
+                        clearInterval(id);
+                        if (errors.length) reject(new Error(errors.join(' | ')));
+                        else resolve({ iterations });
+                    }
+                }, 100);
+            });
+        },
+    },
+    {
+        id: 'A6',
+        group: 'A',
+        title: 'enumerateDevices() from requestAnimationFrame',
+        code: 'requestAnimationFrame(() => enumerateDevices())',
+        run() {
+            return new Promise((resolve, reject) => {
+                requestAnimationFrame(() => {
+                    navigator.mediaDevices.enumerateDevices()
+                        .then((d) => resolve({ count: d.length }))
+                        .catch(reject);
+                });
+            });
+        },
+    },
+    {
+        id: 'A7',
+        group: 'A',
+        title: 'enumerateDevices() from MessageChannel callback',
+        code: 'channel.port1.onmessage = () => enumerateDevices()',
+        run() {
+            return new Promise((resolve, reject) => {
+                const channel = new MessageChannel();
+                channel.port1.onmessage = () => {
+                    navigator.mediaDevices.enumerateDevices()
+                        .then((d) => resolve({ count: d.length }))
+                        .catch(reject);
+                };
+                channel.port2.postMessage('go');
+            });
+        },
+    },
+    {
+        id: 'A8',
+        group: 'A',
+        title: 'enumerateDevices() from queueMicrotask',
+        code: 'queueMicrotask(() => enumerateDevices())',
+        run() {
+            return new Promise((resolve, reject) => {
+                queueMicrotask(() => {
+                    navigator.mediaDevices.enumerateDevices()
+                        .then((d) => resolve({ count: d.length }))
+                        .catch(reject);
+                });
+            });
+        },
+    },
+    {
+        id: 'A9',
+        group: 'A',
+        title: 'devicechange subscription + enumerateDevices()',
+        code: "mediaDevices.addEventListener('devicechange', ...); enumerateDevices()",
+        async run() {
+            const onChange = () => {};
+            navigator.mediaDevices.addEventListener('devicechange', onChange);
+            navigator.mediaDevices.ondevicechange = onChange;
+            try {
+                const d = await navigator.mediaDevices.enumerateDevices();
+                return { count: d.length };
+            } finally {
+                navigator.mediaDevices.removeEventListener('devicechange', onChange);
+                navigator.mediaDevices.ondevicechange = null;
+            }
+        },
+    },
+
+    // Group B — getUserMedia probes (suspected actual trigger).
+    // Each B technique stops the resulting stream immediately so the LED
+    // does not stay on, but the OS prompt will fire on the *attempt*.
+    {
+        id: 'B1',
+        group: 'B',
+        title: 'getUserMedia({ video: true })',
+        code: 'getUserMedia({ video: true })',
+        async run() {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+            return { tracks: await stopStreamTracks(stream) };
+        },
+    },
+    {
+        id: 'B2',
+        group: 'B',
+        title: 'getUserMedia({ audio: true })',
+        code: 'getUserMedia({ audio: true })',
+        async run() {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            return { tracks: await stopStreamTracks(stream) };
+        },
+    },
+    {
+        id: 'B3',
+        group: 'B',
+        title: 'getUserMedia({ video: true, audio: true })',
+        code: 'getUserMedia({ video: true, audio: true })',
+        async run() {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+            return { tracks: await stopStreamTracks(stream) };
+        },
+    },
+    {
+        id: 'B4',
+        group: 'B',
+        title: 'getUserMedia({ video: { facingMode: "user" } })',
+        code: "getUserMedia({ video: { facingMode: 'user' } })",
+        async run() {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' } });
+            return { tracks: await stopStreamTracks(stream) };
+        },
+    },
+    {
+        id: 'B5',
+        group: 'B',
+        title: 'getUserMedia with bogus exact deviceId',
+        code: "getUserMedia({ video: { deviceId: { exact: 'nope' } } })",
+        async run() {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { deviceId: { exact: 'nope-this-id-does-not-exist' } } });
+            return { tracks: await stopStreamTracks(stream) };
+        },
+    },
+    {
+        id: 'B6',
+        group: 'B',
+        title: 'Legacy navigator.getUserMedia (callback form)',
+        code: 'navigator.getUserMedia({ video: true }, cb, cb)',
+        run() {
+            return new Promise((resolve, reject) => {
+                const legacy = navigator.getUserMedia
+                    || navigator.webkitGetUserMedia
+                    || navigator.mozGetUserMedia
+                    || navigator.msGetUserMedia;
+                if (typeof legacy !== 'function') {
+                    reject(new Error('legacy-getUserMedia-unavailable'));
+                    return;
+                }
+                legacy.call(
+                    navigator,
+                    { video: true },
+                    async (stream) => resolve({ tracks: await stopStreamTracks(stream) }),
+                    (err) => reject(err),
+                );
+            });
+        },
+    },
+    {
+        id: 'B7',
+        group: 'B',
+        title: 'getUserMedia x5 parallel',
+        code: 'Promise.allSettled([getUserMedia(...) x5])',
+        async run() {
+            const results = await Promise.allSettled(
+                Array.from({ length: 5 }, () => navigator.mediaDevices.getUserMedia({ video: true })),
+            );
+            const summaries = [];
+            for (const r of results) {
+                if (r.status === 'fulfilled') {
+                    summaries.push({ ok: true, tracks: await stopStreamTracks(r.value) });
+                } else {
+                    summaries.push({ ok: false, error: describeError(r.reason) });
+                }
+            }
+            return { results: summaries };
+        },
+    },
+
+    // Group C — Permissions / supporting APIs
+    {
+        id: 'C1',
+        group: 'C',
+        title: "permissions.query({ name: 'camera' })",
+        code: "navigator.permissions.query({ name: 'camera' })",
+        async run() {
+            const status = await navigator.permissions.query({ name: 'camera' });
+            return { state: status.state };
+        },
+    },
+    {
+        id: 'C2',
+        group: 'C',
+        title: "permissions.query({ name: 'microphone' })",
+        code: "navigator.permissions.query({ name: 'microphone' })",
+        async run() {
+            const status = await navigator.permissions.query({ name: 'microphone' });
+            return { state: status.state };
+        },
+    },
+    {
+        id: 'C3',
+        group: 'C',
+        title: 'getSupportedConstraints()',
+        code: 'navigator.mediaDevices.getSupportedConstraints()',
+        run() {
+            const c = navigator.mediaDevices.getSupportedConstraints();
+            return Promise.resolve({ keys: Object.keys(c) });
+        },
+    },
+    {
+        id: 'C4',
+        group: 'C',
+        title: 'getDisplayMedia({ video: true })',
+        code: 'navigator.mediaDevices.getDisplayMedia({ video: true })',
+        async run() {
+            const stream = await navigator.mediaDevices.getDisplayMedia({ video: true });
+            return { tracks: await stopStreamTracks(stream) };
+        },
+    },
+    {
+        id: 'C5',
+        group: 'C',
+        title: 'getUserMedia + track.getCapabilities/Settings/Constraints',
+        code: 'gum().then(s => s.getVideoTracks()[0].getCapabilities()/getSettings()/getConstraints())',
+        async run() {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+            try {
+                const track = stream.getVideoTracks()[0];
+                const capabilities = typeof track.getCapabilities === 'function' ? track.getCapabilities() : null;
+                const settings = typeof track.getSettings === 'function' ? track.getSettings() : null;
+                const constraints = typeof track.getConstraints === 'function' ? track.getConstraints() : null;
+                return {
+                    capabilityKeys: capabilities ? Object.keys(capabilities) : null,
+                    settingKeys: settings ? Object.keys(settings) : null,
+                    constraintKeys: constraints ? Object.keys(constraints) : null,
+                };
+            } finally {
+                await stopStreamTracks(stream);
+            }
+        },
+    },
+
+    // Group D — RTCPeerConnection (often used in fingerprinting / WebRTC ICE)
+    {
+        id: 'D1',
+        group: 'D',
+        title: 'new RTCPeerConnection() + close()',
+        code: 'new RTCPeerConnection(); pc.close()',
+        async run() {
+            const pc = new RTCPeerConnection();
+            const ok = { connectionState: pc.connectionState, iceConnectionState: pc.iceConnectionState };
+            pc.close();
+            return ok;
+        },
+    },
+    {
+        id: 'D2',
+        group: 'D',
+        title: 'pc.createOffer({ offerToReceiveVideo, offerToReceiveAudio })',
+        code: 'pc.createOffer({ offerToReceiveVideo: true, offerToReceiveAudio: true })',
+        async run() {
+            const pc = new RTCPeerConnection();
+            try {
+                const offer = await pc.createOffer({ offerToReceiveVideo: true, offerToReceiveAudio: true });
+                return { sdpType: offer.type, sdpLength: offer.sdp.length };
+            } finally {
+                pc.close();
+            }
+        },
+    },
+    {
+        id: 'D3',
+        group: 'D',
+        title: 'pc.addTransceiver("video", recvonly)',
+        code: "pc.addTransceiver('video', { direction: 'recvonly' })",
+        async run() {
+            const pc = new RTCPeerConnection();
+            try {
+                const tx = pc.addTransceiver('video', { direction: 'recvonly' });
+                return { direction: tx.direction, kind: tx.receiver.track ? tx.receiver.track.kind : null };
+            } finally {
+                pc.close();
+            }
+        },
+    },
+
+    // Group E — iframe contexts. Each runs A1 (enumerateDevices) then B1
+    // (getUserMedia) inside a different iframe variant. Same-origin only —
+    // a cross-origin variant already exists at features/iframe-media-prompt.html.
+    {
+        id: 'E1',
+        group: 'E',
+        title: 'Regular same-origin iframe — A1 + B1',
+        code: '<iframe src="iframe-child.html" allow="camera; microphone">',
+        async run() {
+            const iframe = await makeIframeFromSrc();
+            try {
+                const a = await sendChaosToFrame(iframe, 'A1');
+                let b = null;
+                let bError = null;
+                try {
+                    b = await sendChaosToFrame(iframe, 'B1');
+                } catch (e) {
+                    bError = describeError(e);
+                }
+                return { a, b, bError };
+            } finally {
+                iframe.remove();
+            }
+        },
+    },
+    {
+        id: 'E2',
+        group: 'E',
+        title: 'Sandboxed same-origin iframe — A1 + B1',
+        code: 'sandbox="allow-scripts allow-same-origin"',
+        async run() {
+            const iframe = await makeIframeFromSrc({ sandbox: 'allow-scripts allow-same-origin' });
+            try {
+                const a = await sendChaosToFrame(iframe, 'A1');
+                let b = null;
+                let bError = null;
+                try {
+                    b = await sendChaosToFrame(iframe, 'B1');
+                } catch (e) {
+                    bError = describeError(e);
+                }
+                return { a, b, bError };
+            } finally {
+                iframe.remove();
+            }
+        },
+    },
+    {
+        id: 'E3',
+        group: 'E',
+        title: 'srcdoc iframe — A1 + B1',
+        code: '<iframe srcdoc="...">',
+        async run() {
+            const res = await fetch(IFRAME_CHILD_URL);
+            const html = await res.text();
+            const iframe = await makeIframeSrcdoc(html);
+            try {
+                const a = await sendChaosToFrame(iframe, 'A1');
+                let b = null;
+                let bError = null;
+                try {
+                    b = await sendChaosToFrame(iframe, 'B1');
+                } catch (e) {
+                    bError = describeError(e);
+                }
+                return { a, b, bError };
+            } finally {
+                iframe.remove();
+            }
+        },
+    },
+    {
+        id: 'E4',
+        group: 'E',
+        title: 'document.write iframe — A1 + B1',
+        code: 'doc.open(); doc.write(html); doc.close()',
+        async run() {
+            const iframe = await makeIframeDocumentWrite();
+            try {
+                const a = await sendChaosToFrame(iframe, 'A1');
+                let b = null;
+                let bError = null;
+                try {
+                    b = await sendChaosToFrame(iframe, 'B1');
+                } catch (e) {
+                    bError = describeError(e);
+                }
+                return { a, b, bError };
+            } finally {
+                iframe.remove();
+            }
+        },
+    },
+    {
+        id: 'E5',
+        group: 'E',
+        title: 'Iframe inserted 3s after click — A1 + B1',
+        code: 'await delay(3000); insert iframe; run',
+        async run() {
+            await delay(3000);
+            const iframe = await makeIframeFromSrc();
+            try {
+                const a = await sendChaosToFrame(iframe, 'A1');
+                let b = null;
+                let bError = null;
+                try {
+                    b = await sendChaosToFrame(iframe, 'B1');
+                } catch (e) {
+                    bError = describeError(e);
+                }
+                return { a, b, bError };
+            } finally {
+                iframe.remove();
+            }
+        },
+    },
+    {
+        id: 'E6',
+        group: 'E',
+        title: 'Hidden (display:none) iframe — A1 + B1',
+        code: 'iframe.style.display = "none"',
+        async run() {
+            const iframe = await makeIframeFromSrc({ style: 'display:none' });
+            try {
+                const a = await sendChaosToFrame(iframe, 'A1');
+                let b = null;
+                let bError = null;
+                try {
+                    b = await sendChaosToFrame(iframe, 'B1');
+                } catch (e) {
+                    bError = describeError(e);
+                }
+                return { a, b, bError };
+            } finally {
+                iframe.remove();
+            }
+        },
+    },
+];
+
+const GROUPS = [
+    { id: 'A', title: 'A — enumerateDevices() variants', description: 'Directly probe MediaDevices.enumerateDevices() across call shapes and event-loop contexts.' },
+    { id: 'B', title: 'B — getUserMedia() probes', description: 'Direct media-stream requests. These will legitimately prompt for camera/mic on any browser; the question for OPS-7378 is whether they ALSO surface the Windows OS prompt above the in-app prompt.' },
+    { id: 'C', title: 'C — Permissions and supporting APIs', description: 'Permissions API + adjacent MediaDevices APIs (getSupportedConstraints, getDisplayMedia, MediaStreamTrack.getCapabilities).' },
+    { id: 'D', title: 'D — RTCPeerConnection', description: 'WebRTC paths commonly used for fingerprinting (offer/transceiver creation).' },
+    { id: 'E', title: 'E — Iframe contexts (same-origin)', description: 'Same-origin iframe variants run A1+B1 inside an embedded document. A cross-origin variant already exists at features/iframe-media-prompt.html.' },
+];
+
+function renderTechniques() {
+    for (const group of GROUPS) {
+        const groupTechs = TECHNIQUES.filter((t) => t.group === group.id);
+        const section = document.createElement('section');
+        section.className = 'group';
+
+        const header = document.createElement('div');
+        header.className = 'group-header';
+        const h3 = document.createElement('h3');
+        h3.textContent = group.title;
+        const p = document.createElement('p');
+        p.textContent = group.description;
+        header.appendChild(h3);
+        header.appendChild(p);
+        section.appendChild(header);
+
+        for (const tech of groupTechs) {
+            const row = document.createElement('div');
+            row.className = 'tech-row';
+            row.id = `row-${tech.id}`;
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'tech-button';
+            button.textContent = `Run ${tech.id}`;
+            button.dataset.techniqueId = tech.id;
+            button.addEventListener('click', () => runSingle(tech.id));
+
+            const meta = document.createElement('div');
+            meta.className = 'tech-meta';
+            const titleEl = document.createElement('strong');
+            titleEl.textContent = tech.title;
+            const codeEl = document.createElement('code');
+            codeEl.textContent = tech.code;
+            meta.appendChild(titleEl);
+            meta.appendChild(codeEl);
+
+            const status = document.createElement('div');
+            status.className = 'tech-status';
+            status.dataset.state = 'idle';
+            status.textContent = 'idle';
+            status.id = `status-${tech.id}`;
+
+            const promptSelect = document.createElement('select');
+            promptSelect.className = 'tech-prompt';
+            promptSelect.id = `prompt-${tech.id}`;
+            for (const opt of [
+                ['not-answered', 'OS prompt? (not answered)'],
+                ['yes', 'Yes — OS prompt appeared'],
+                ['no', 'No prompt'],
+                ['in-browser-only', 'In-browser prompt only'],
+                ['already-granted', 'Already granted'],
+                ['already-denied', 'Already denied'],
+            ]) {
+                const o = document.createElement('option');
+                o.value = opt[0];
+                o.textContent = opt[1];
+                promptSelect.appendChild(o);
+            }
+            promptSelect.addEventListener('change', () => {
+                if (!state.results[tech.id]) state.results[tech.id] = {};
+                state.results[tech.id].osPromptObserved = promptSelect.value;
+            });
+
+            row.appendChild(button);
+            row.appendChild(meta);
+            row.appendChild(status);
+            row.appendChild(promptSelect);
+            section.appendChild(row);
+        }
+
+        techniquesEl.appendChild(section);
+    }
+}
+
+function setStatus(techId, stateName, text) {
+    const el = document.getElementById(`status-${techId}`);
+    if (!el) return;
+    el.dataset.state = stateName;
+    el.textContent = text;
+}
+
+function setButtonsDisabled(disabled) {
+    for (const btn of document.querySelectorAll('.tech-button')) {
+        btn.disabled = disabled;
+    }
+}
+
+async function runSingle(techId) {
+    const tech = TECHNIQUES.find((t) => t.id === techId);
+    if (!tech) return null;
+
+    setStatus(techId, 'running', 'running...');
+    log(`${techId} start: ${tech.title}`);
+
+    const started = performance.now();
+    const entry = {
+        id: techId,
+        title: tech.title,
+        startedAt: new Date().toISOString(),
+        osPromptObserved: state.results[techId]?.osPromptObserved ?? 'not-answered',
+    };
+
+    try {
+        const value = await tech.run();
+        entry.ok = true;
+        entry.value = value;
+        entry.durationMs = Math.round(performance.now() - started);
+        setStatus(techId, 'ok', `ok (${entry.durationMs}ms)`);
+        log(`${techId} ok`, value);
+    } catch (err) {
+        entry.ok = false;
+        entry.error = describeError(err);
+        entry.durationMs = Math.round(performance.now() - started);
+        setStatus(techId, 'error', entry.error);
+        log(`${techId} error`, entry.error);
+    }
+
+    state.results[techId] = { ...(state.results[techId] || {}), ...entry };
+    return entry;
+}
+
+async function unleashAll() {
+    setButtonsDisabled(true);
+    unleashButton.disabled = true;
+    const total = TECHNIQUES.length;
+    let i = 0;
+    log(`Unleash chaos: running ${total} techniques`);
+    for (const tech of TECHNIQUES) {
+        i++;
+        unleashProgress.textContent = `Running ${i} / ${total}: ${tech.id}`;
+        await runSingle(tech.id);
+        await delay(150);
+    }
+    unleashProgress.textContent = `Done — ran ${total} techniques.`;
+    log('Unleash chaos: complete');
+    setButtonsDisabled(false);
+    unleashButton.disabled = false;
+    logEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function downloadResults() {
+    state.overallPromptObserved = overallPromptSelect.value;
+    state.finishedAt = new Date().toISOString();
+    state.diagnosticsAtDownload = collectDiagnostics();
+    const payload = JSON.stringify(state, null, 2);
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `device-enumeration-chaos-${Date.now()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+}
+
+function resetResults() {
+    state.results = {};
+    state.overallPromptObserved = 'not-answered';
+    overallPromptSelect.value = 'not-answered';
+    unleashProgress.textContent = '';
+    logEl.textContent = '';
+    for (const tech of TECHNIQUES) {
+        setStatus(tech.id, 'idle', 'idle');
+        const p = document.getElementById(`prompt-${tech.id}`);
+        if (p) p.value = 'not-answered';
+    }
+    log('State reset');
+}
+
+function renderDiagnostics() {
+    const dl = document.getElementById('diagnostic-list');
+    for (const [key, value] of Object.entries(state.diagnostics)) {
+        const dt = document.createElement('dt');
+        dt.textContent = key;
+        const dd = document.createElement('dd');
+        dd.textContent = typeof value === 'string' ? value : JSON.stringify(value);
+        dl.appendChild(dt);
+        dl.appendChild(dd);
+    }
+}
+
+unleashButton.addEventListener('click', () => {
+    confirmDialog.showModal();
+});
+confirmGoButton.addEventListener('click', () => {
+    confirmDialog.close();
+    unleashAll();
+});
+confirmCancelButton.addEventListener('click', () => confirmDialog.close());
+downloadButton.addEventListener('click', downloadResults);
+resetButton.addEventListener('click', resetResults);
+overallPromptSelect.addEventListener('change', () => {
+    state.overallPromptObserved = overallPromptSelect.value;
+});
+
+renderDiagnostics();
+renderTechniques();
+log(`Ready — ${TECHNIQUES.length} techniques loaded.`);

--- a/features/device-enumeration-chaos/style.css
+++ b/features/device-enumeration-chaos/style.css
@@ -1,0 +1,264 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    color: #111;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    line-height: 1.45;
+    margin: 16px;
+    max-width: 1200px;
+}
+
+code,
+pre,
+button,
+select,
+input {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.banner {
+    background: #fff5f5;
+    border: 1px solid #d94545;
+    border-radius: 4px;
+    padding: 12px 16px;
+    margin: 12px 0 20px;
+}
+
+.banner h2 {
+    color: #a31515;
+    margin: 0 0 8px;
+}
+
+.unleash-bar {
+    align-items: center;
+    background: #fff;
+    border: 2px solid #a31515;
+    border-radius: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin: 16px 0;
+    padding: 12px 16px;
+}
+
+.unleash-bar button {
+    background: #a31515;
+    border: 1px solid #7a0f0f;
+    border-radius: 4px;
+    color: #fff;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 700;
+    padding: 8px 18px;
+}
+
+.unleash-bar button:hover:not(:disabled) {
+    background: #c01b1b;
+}
+
+.unleash-bar button:disabled {
+    background: #888;
+    border-color: #666;
+    cursor: not-allowed;
+}
+
+.unleash-progress {
+    font-weight: 700;
+}
+
+.diagnostic {
+    background: #f6f6f6;
+    border: 1px solid #d0d0d0;
+    border-radius: 4px;
+    margin: 12px 0;
+    padding: 10px 12px;
+}
+
+.diagnostic dl {
+    display: grid;
+    gap: 4px 12px;
+    grid-template-columns: max-content minmax(0, 1fr);
+    margin: 0;
+}
+
+.diagnostic dt {
+    font-weight: 700;
+}
+
+.diagnostic dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+.group {
+    border: 1px solid #d0d0d0;
+    border-radius: 4px;
+    margin: 16px 0;
+    overflow: hidden;
+}
+
+.group-header {
+    background: #f0f4ff;
+    border-bottom: 1px solid #d0d0d0;
+    padding: 10px 12px;
+}
+
+.group-header h3 {
+    margin: 0;
+}
+
+.group-header p {
+    color: #555;
+    margin: 4px 0 0;
+}
+
+.tech-row {
+    border-bottom: 1px solid #eee;
+    display: grid;
+    gap: 8px 12px;
+    grid-template-columns: 70px 1fr 280px 110px;
+    align-items: center;
+    padding: 10px 12px;
+}
+
+.tech-row:last-child {
+    border-bottom: none;
+}
+
+@media (max-width: 900px) {
+    .tech-row {
+        grid-template-columns: 1fr;
+    }
+}
+
+.tech-meta strong {
+    display: block;
+    font-size: 14px;
+}
+
+.tech-meta code {
+    color: #555;
+    font-size: 12px;
+    word-break: break-all;
+}
+
+.tech-button {
+    background: #fff;
+    border: 1px solid #888;
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 6px 10px;
+    text-align: center;
+    width: 100%;
+}
+
+.tech-button:hover:not(:disabled) {
+    background: #f0f0f0;
+}
+
+.tech-button:disabled {
+    background: #eee;
+    color: #888;
+    cursor: not-allowed;
+}
+
+.tech-status {
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tech-status[data-state="idle"] {
+    color: #888;
+}
+
+.tech-status[data-state="running"] {
+    color: #b58900;
+}
+
+.tech-status[data-state="ok"] {
+    color: #1a7f37;
+}
+
+.tech-status[data-state="error"] {
+    color: #a31515;
+}
+
+.tech-prompt {
+    font-size: 12px;
+    padding: 4px;
+    width: 100%;
+}
+
+.results-bar {
+    align-items: center;
+    background: #f6f6f6;
+    border: 1px solid #d0d0d0;
+    border-radius: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin: 16px 0;
+    padding: 10px 12px;
+}
+
+.results-bar button {
+    cursor: pointer;
+    padding: 6px 12px;
+}
+
+.results-bar label {
+    align-items: center;
+    display: flex;
+    gap: 6px;
+}
+
+.log-panel {
+    background: #1e1e1e;
+    border: 1px solid #444;
+    border-radius: 4px;
+    color: #ddd;
+    font-size: 12px;
+    margin-top: 8px;
+    max-height: 360px;
+    overflow: auto;
+    padding: 10px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+dialog {
+    border: 1px solid #888;
+    border-radius: 6px;
+    max-width: 520px;
+    padding: 20px;
+}
+
+dialog h3 {
+    margin-top: 0;
+}
+
+dialog .dialog-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 16px;
+}
+
+dialog button {
+    cursor: pointer;
+    padding: 6px 14px;
+}
+
+dialog .danger {
+    background: #a31515;
+    border: 1px solid #7a0f0f;
+    color: #fff;
+}

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
 	<li><a href="./features/web-interference-detection/">Web Interference Detection</a></li>
 	<li><a href="./features/iframe-permissions.html">Site Permissions (iframe identity)</a> — verifies which origin the browser uses for permission storage when a permission is requested from an iframe</li>
 	<li><a href="./features/iframe-media-prompt.html">Iframe Media Prompt Repro</a> — triggers a Claude-like cross-origin iframe <code>enumerateDevices()</code> + <code>getUserMedia()</code> sequence to verify prompt visibility vs iframe API blocking</li>
+	<li><a href="./features/device-enumeration-chaos/">Device Enumeration Chaos</a> — catalogue of <code>enumerateDevices</code>, <code>getUserMedia</code>, permissions and <code>RTCPeerConnection</code> calls to isolate which API surfaces the Windows OS camera prompt (OPS-7378)</li>
 </ul>
 
 <h2>Security</h2>


### PR DESCRIPTION


Covers:
- A: enumerateDevices() across call shapes and event-loop contexts
- B: getUserMedia() variants (incl. legacy callback form, bogus deviceId)
- C: permissions.query, getSupportedConstraints, getDisplayMedia, MediaStreamTrack.getCapabilities/getSettings/getConstraints
- D: RTCPeerConnection (createOffer, addTransceiver)
- E: same-origin iframe contexts (regular, sandboxed, srcdoc, document.write, delayed-insert, hidden)

A cross-origin iframe variant already exists at
features/iframe-media-prompt.html.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new static test pages and a home-page link, with no impact on production logic. Main risk is testers triggering intentional camera/mic prompts when running the `getUserMedia` techniques.
> 
> **Overview**
> Adds a new `features/device-enumeration-chaos/` repro tool for OPS-7378 that runs a catalogue of media-device techniques (`enumerateDevices`, multiple `getUserMedia` variants, `permissions.query`, `getDisplayMedia`, and `RTCPeerConnection`), including same-origin iframe variants driven via `postMessage`.
> 
> The page provides per-technique run buttons, a full “unleash chaos” sequential runner with confirmation, runtime diagnostics, logging, and JSON export/reset of observed prompt results, and is linked from the root `index.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998326698de723fea22cea868b422a74ae256792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->