### PR TITLE
Add more enumeration tests

### DIFF
--- a/features/device-enumeration-chaos/index.html
+++ b/features/device-enumeration-chaos/index.html
@@ -36,6 +36,8 @@
         </p>
     </div>
 
+    <div id="environment-warnings" class="environment-warning" hidden></div>
+
     <div class="diagnostic">
         <strong>Runtime diagnostics</strong>
         <dl id="diagnostic-list"></dl>

--- a/features/device-enumeration-chaos/index.html
+++ b/features/device-enumeration-chaos/index.html
@@ -34,6 +34,13 @@
             those calls surface the <em>native Windows OS prompt</em> in addition to or instead of the
             in-app permission UI.
         </p>
+        <p>
+            For the cross-origin third-party iframe scenario (the actual shape protechts.net /
+            HUMAN Security takes on linkedin.com — top-level page in one origin, fingerprinting iframe in
+            another with <code>allow="camera; microphone"</code>), use the existing
+            <a href="../iframe-media-prompt.html">Iframe Media Prompt Repro</a> page. The
+            <em>E group</em> below covers same-origin iframe variants only.
+        </p>
     </div>
 
     <div id="environment-warnings" class="environment-warning" hidden></div>

--- a/features/device-enumeration-chaos/main.js
+++ b/features/device-enumeration-chaos/main.js
@@ -85,6 +85,136 @@ function scheduledEnumerate(schedule) {
     });
 }
 
+/*
+ * Spawn a Web Worker built from a Blob URL that probes for navigator.mediaDevices
+ * inside worker scope. Per spec mediaDevices is NOT exposed in workers, but
+ * reCAPTCHA Enterprise's webworker.js literally importScripts() the full
+ * recaptcha bundle (which expects mediaDevices) — so this is worth verifying
+ * on the build under test.
+ */
+function runInWebWorker() {
+    return new Promise((resolve, reject) => {
+        const source = `
+            self.addEventListener('message', async () => {
+                const result = {
+                    selfNavigatorPresent: typeof self.navigator !== 'undefined',
+                    mediaDevicesPresent: typeof self.navigator !== 'undefined' && Boolean(self.navigator.mediaDevices),
+                    enumerateDevicesPresent: typeof self.navigator !== 'undefined'
+                        && Boolean(self.navigator.mediaDevices)
+                        && typeof self.navigator.mediaDevices.enumerateDevices === 'function',
+                    getUserMediaPresent: typeof self.navigator !== 'undefined'
+                        && Boolean(self.navigator.mediaDevices)
+                        && typeof self.navigator.mediaDevices.getUserMedia === 'function',
+                };
+                try {
+                    if (result.enumerateDevicesPresent) {
+                        const devices = await self.navigator.mediaDevices.enumerateDevices();
+                        result.enumerateDevicesCount = devices.length;
+                        result.enumerateDevicesKinds = devices.map((d) => d.kind);
+                    }
+                } catch (e) {
+                    result.enumerateDevicesError = (e && (e.name + ': ' + e.message)) || String(e);
+                }
+                try {
+                    if (result.getUserMediaPresent) {
+                        const stream = await self.navigator.mediaDevices.getUserMedia({ video: true });
+                        result.getUserMediaOk = true;
+                        for (const t of stream.getTracks()) t.stop();
+                    }
+                } catch (e) {
+                    result.getUserMediaError = (e && (e.name + ': ' + e.message)) || String(e);
+                }
+                self.postMessage(result);
+            });
+        `;
+        const blob = new Blob([source], { type: 'application/javascript' });
+        const url = URL.createObjectURL(blob);
+        let worker;
+        try {
+            worker = new Worker(url);
+        } catch (e) {
+            URL.revokeObjectURL(url);
+            reject(e);
+            return;
+        }
+        const cleanup = () => {
+            URL.revokeObjectURL(url);
+            try { worker.terminate(); } catch (e) { /* ignore */ }
+        };
+        const timer = setTimeout(() => {
+            cleanup();
+            reject(new Error('worker-response-timeout'));
+        }, IFRAME_RESPONSE_TIMEOUT_MS);
+        worker.addEventListener('message', (event) => {
+            clearTimeout(timer);
+            cleanup();
+            resolve(event.data);
+        });
+        worker.addEventListener('error', (event) => {
+            clearTimeout(timer);
+            cleanup();
+            reject(new Error(event.message || 'worker-error'));
+        });
+        worker.postMessage('go');
+    });
+}
+
+/*
+ * Full ICE-leak pattern as used by LinkedIn's first-party getIPs() in
+ * static.licdn.com/aero-v1/.../CtQciDL0.js and by countless fingerprinting
+ * libraries. Creates a peer connection with a STUN server, opens a data
+ * channel (needed to gather candidates without addTrack), creates and
+ * sets a local offer, then accumulates candidates for the given duration.
+ */
+function collectIceCandidates(timeoutMs) {
+    return new Promise((resolve, reject) => {
+        let pc;
+        try {
+            pc = new RTCPeerConnection({
+                iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+            });
+        } catch (e) {
+            reject(e);
+            return;
+        }
+        const candidates = [];
+        pc.onicecandidate = (event) => {
+            if (event.candidate) {
+                candidates.push({
+                    type: event.candidate.type,
+                    protocol: event.candidate.protocol,
+                    address: event.candidate.address,
+                    port: event.candidate.port,
+                    candidate: event.candidate.candidate,
+                });
+            }
+        };
+        try {
+            pc.createDataChannel('chaos-icetest');
+        } catch (e) {
+            try { pc.close(); } catch (closeErr) { /* ignore */ }
+            reject(e);
+            return;
+        }
+        pc.createOffer()
+            .then((offer) => pc.setLocalDescription(offer))
+            .catch((e) => {
+                try { pc.close(); } catch (closeErr) { /* ignore */ }
+                reject(e);
+            });
+        setTimeout(() => {
+            const result = {
+                candidateCount: candidates.length,
+                types: Array.from(new Set(candidates.map((c) => c.type))),
+                addresses: Array.from(new Set(candidates.map((c) => c.address).filter(Boolean))),
+                gatheringState: pc.iceGatheringState,
+            };
+            try { pc.close(); } catch (e) { /* ignore */ }
+            resolve(result);
+        }, timeoutMs);
+    });
+}
+
 function collectDiagnostics() {
     const md = navigator.mediaDevices;
     const enumerateFnSource = md && md.enumerateDevices ? Function.prototype.toString.call(md.enumerateDevices) : null;
@@ -313,6 +443,24 @@ const TECHNIQUES = [
             }
         },
     },
+    {
+        id: 'A10',
+        group: 'A',
+        title: 'enumerateDevices() + check for videoinput/audioinput/audiooutput (reCAPTCHA pattern)',
+        code: "devices.some(d => d.kind === 'videoinput')",
+        async run() {
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            const kinds = devices.map((d) => d.kind);
+            return {
+                count: devices.length,
+                hasVideoInput: kinds.includes('videoinput'),
+                hasAudioInput: kinds.includes('audioinput'),
+                hasAudioOutput: kinds.includes('audiooutput'),
+                allLabelsEmpty: devices.every((d) => d.label === ''),
+                allDeviceIdsEmpty: devices.every((d) => d.deviceId === ''),
+            };
+        },
+    },
 
     // Group B — getUserMedia probes (suspected actual trigger).
     // Each B technique stops the resulting stream immediately so the LED
@@ -409,6 +557,15 @@ const TECHNIQUES = [
                 }
             }
             return { results: summaries };
+        },
+    },
+    {
+        id: 'B8',
+        group: 'B',
+        title: 'Web Worker probe (mediaDevices availability + enumerateDevices + getUserMedia)',
+        code: "new Worker(blob); self.navigator.mediaDevices?.enumerateDevices()",
+        async run() {
+            return runInWebWorker();
         },
     },
 
@@ -517,6 +674,15 @@ const TECHNIQUES = [
             } finally {
                 pc.close();
             }
+        },
+    },
+    {
+        id: 'D4',
+        group: 'D',
+        title: 'Full WebRTC ICE-leak pattern (LinkedIn first-party getIPs)',
+        code: "new RTCPeerConnection({iceServers}); createDataChannel(); createOffer(); setLocalDescription(); collect candidates 3s",
+        async run() {
+            return collectIceCandidates(3000);
         },
     },
 
@@ -658,14 +824,35 @@ const TECHNIQUES = [
             }
         },
     },
+
+    // Group F — Macro sequences (compositions of other techniques).
+    // The runner records each constituent in its own row alongside the macro,
+    // so the tester can see which step within the sequence triggered the prompt.
+    {
+        id: 'F0',
+        group: 'F',
+        title: 'PerimeterX-style probe sequence (C1 → C2 → B5 → B1)',
+        code: "permissions.query({name:'camera'}); permissions.query({name:'microphone'}); getUserMedia({deviceId:{exact:'nope'}}); getUserMedia({video:true})",
+        async run() {
+            const steps = ['C1', 'C2', 'B5', 'B1'];
+            const results = [];
+            for (const step of steps) {
+                const entry = await runSingle(step);
+                results.push({ id: step, ok: entry && entry.ok, error: entry && entry.error, value: entry && entry.value });
+                await delay(300);
+            }
+            return { steps: results };
+        },
+    },
 ];
 
 const GROUPS = [
     { id: 'A', title: 'A — enumerateDevices() variants', description: 'Directly probe MediaDevices.enumerateDevices() across call shapes and event-loop contexts.' },
     { id: 'B', title: 'B — getUserMedia() probes', description: 'Direct media-stream requests. These will legitimately prompt for camera/mic on any browser; the question for OPS-7378 is whether they ALSO surface the Windows OS prompt above the in-app prompt.' },
     { id: 'C', title: 'C — Permissions and supporting APIs', description: 'Permissions API + adjacent MediaDevices APIs (getSupportedConstraints, getDisplayMedia, MediaStreamTrack.getCapabilities).' },
-    { id: 'D', title: 'D — RTCPeerConnection', description: 'WebRTC paths commonly used for fingerprinting (offer/transceiver creation).' },
+    { id: 'D', title: 'D — RTCPeerConnection', description: 'WebRTC paths commonly used for fingerprinting (offer/transceiver creation, full ICE-leak pattern).' },
     { id: 'E', title: 'E — Iframe contexts (same-origin)', description: 'Same-origin iframe variants run A1+B1 inside an embedded document. A cross-origin variant already exists at features/iframe-media-prompt.html.' },
+    { id: 'F', title: 'F — Macro sequences', description: 'Compositions of other techniques. Each constituent records into its own row in the catalogue above, so the tester can see which step within the sequence triggered the prompt.' },
 ];
 
 function renderTechniques() {

--- a/features/device-enumeration-chaos/main.js
+++ b/features/device-enumeration-chaos/main.js
@@ -63,6 +63,28 @@ function delay(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/*
+ * Promise-wraps an enumerateDevices() call scheduled via an arbitrary
+ * callback (setTimeout, requestAnimationFrame, MessageChannel, ...). The
+ * scheduled callback body is wrapped in try/catch so that a synchronous
+ * throw (e.g. navigator.mediaDevices being undefined in a non-secure
+ * context) propagates as a Promise rejection instead of escaping the
+ * Promise executor and leaving the outer Promise hanging.
+ */
+function scheduledEnumerate(schedule) {
+    return new Promise((resolve, reject) => {
+        schedule(() => {
+            try {
+                navigator.mediaDevices.enumerateDevices()
+                    .then((d) => resolve({ count: d.length }))
+                    .catch(reject);
+            } catch (e) {
+                reject(e);
+            }
+        });
+    });
+}
+
 function collectDiagnostics() {
     const md = navigator.mediaDevices;
     const enumerateFnSource = md && md.enumerateDevices ? Function.prototype.toString.call(md.enumerateDevices) : null;
@@ -218,15 +240,7 @@ const TECHNIQUES = [
         group: 'A',
         title: 'enumerateDevices() from setTimeout(0)',
         code: 'setTimeout(() => enumerateDevices(), 0)',
-        run() {
-            return new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    navigator.mediaDevices.enumerateDevices()
-                        .then((d) => resolve({ count: d.length }))
-                        .catch(reject);
-                }, 0);
-            });
-        },
+        run: () => scheduledEnumerate((cb) => setTimeout(cb, 0)),
     },
     {
         id: 'A5',
@@ -234,10 +248,16 @@ const TECHNIQUES = [
         title: 'enumerateDevices() x10 from setInterval / 100ms',
         code: 'setInterval(() => enumerateDevices(), 100) x10',
         async run() {
-            const pending = await new Promise((resolve) => {
+            const pending = await new Promise((resolve, reject) => {
                 const promises = [];
                 const id = setInterval(() => {
-                    promises.push(navigator.mediaDevices.enumerateDevices());
+                    try {
+                        promises.push(navigator.mediaDevices.enumerateDevices());
+                    } catch (e) {
+                        clearInterval(id);
+                        reject(e);
+                        return;
+                    }
                     if (promises.length >= 10) {
                         clearInterval(id);
                         resolve(promises);
@@ -255,47 +275,25 @@ const TECHNIQUES = [
         group: 'A',
         title: 'enumerateDevices() from requestAnimationFrame',
         code: 'requestAnimationFrame(() => enumerateDevices())',
-        run() {
-            return new Promise((resolve, reject) => {
-                requestAnimationFrame(() => {
-                    navigator.mediaDevices.enumerateDevices()
-                        .then((d) => resolve({ count: d.length }))
-                        .catch(reject);
-                });
-            });
-        },
+        run: () => scheduledEnumerate((cb) => requestAnimationFrame(cb)),
     },
     {
         id: 'A7',
         group: 'A',
         title: 'enumerateDevices() from MessageChannel callback',
         code: 'channel.port1.onmessage = () => enumerateDevices()',
-        run() {
-            return new Promise((resolve, reject) => {
-                const channel = new MessageChannel();
-                channel.port1.onmessage = () => {
-                    navigator.mediaDevices.enumerateDevices()
-                        .then((d) => resolve({ count: d.length }))
-                        .catch(reject);
-                };
-                channel.port2.postMessage('go');
-            });
-        },
+        run: () => scheduledEnumerate((cb) => {
+            const channel = new MessageChannel();
+            channel.port1.onmessage = cb;
+            channel.port2.postMessage('go');
+        }),
     },
     {
         id: 'A8',
         group: 'A',
         title: 'enumerateDevices() from queueMicrotask',
         code: 'queueMicrotask(() => enumerateDevices())',
-        run() {
-            return new Promise((resolve, reject) => {
-                queueMicrotask(() => {
-                    navigator.mediaDevices.enumerateDevices()
-                        .then((d) => resolve({ count: d.length }))
-                        .catch(reject);
-                });
-            });
-        },
+        run: () => scheduledEnumerate((cb) => queueMicrotask(cb)),
     },
     {
         id: 'A9',
@@ -867,6 +865,29 @@ overallPromptSelect.addEventListener('change', () => {
     state.overallPromptObserved = overallPromptSelect.value;
 });
 
+function renderEnvironmentWarnings() {
+    const warnings = [];
+    if (!navigator.mediaDevices) {
+        warnings.push(
+            'navigator.mediaDevices is undefined on this page. Most techniques will fail with TypeError. '
+            + 'This usually means the page is not running in a secure context (HTTPS or localhost). '
+            + 'Try opening the page over HTTPS, or via the privacy-test-pages site rather than a plain IP.',
+        );
+    }
+    if (!window.isSecureContext) {
+        warnings.push('isSecureContext is false — media-device APIs may be unavailable or behave unexpectedly.');
+    }
+    if (!warnings.length) return;
+    const warningEl = document.getElementById('environment-warnings');
+    warningEl.hidden = false;
+    for (const text of warnings) {
+        const p = document.createElement('p');
+        p.textContent = text;
+        warningEl.appendChild(p);
+    }
+}
+
 renderDiagnostics();
+renderEnvironmentWarnings();
 renderTechniques();
 log(`Ready — ${TECHNIQUES.length} techniques loaded.`);

--- a/features/device-enumeration-chaos/style.css
+++ b/features/device-enumeration-chaos/style.css
@@ -68,6 +68,19 @@ input {
     font-weight: 700;
 }
 
+.environment-warning {
+    background: #fff8e1;
+    border: 2px solid #d4a300;
+    border-radius: 4px;
+    color: #5b3d00;
+    margin: 12px 0;
+    padding: 10px 14px;
+}
+
+.environment-warning p {
+    margin: 4px 0;
+}
+
 .diagnostic {
     background: #f6f6f6;
     border: 1px solid #d0d0d0;


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/949243614371883/task/1214933948986277?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a local repro/test page and primarily add new diagnostic/probing scenarios plus better error handling.
> 
> **Overview**
> Expands the `device-enumeration-chaos` repro page with additional probe techniques and clearer guidance for isolating the Windows OS camera prompt trigger.
> 
> Adds new scenarios including an `enumerateDevices()` kind/label check (reCAPTCHA-style), a Blob-based **Web Worker** probe for `mediaDevices`/`enumerateDevices`/`getUserMedia`, a full **WebRTC ICE candidate collection** flow (LinkedIn getIPs-style), and a **macro sequence** runner (PerimeterX-style) that chains existing steps.
> 
> Refactors scheduled `enumerateDevices()` variants to use a shared `scheduledEnumerate()` wrapper with safer try/catch behavior, and adds an in-page **secure-context/environment warning** banner with matching styling plus a note linking to the separate cross-origin iframe repro page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a65e6759cc5160ed5d8033ff84a659e1d36bea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->