### PR TITLE
Add more tests

### DIFF
--- a/features/device-enumeration-chaos/index.html
+++ b/features/device-enumeration-chaos/index.html
@@ -50,6 +50,27 @@
         <dl id="diagnostic-list"></dl>
     </div>
 
+    <div class="instrumentation-bar">
+        <div class="instrumentation-controls">
+            <button id="instrument-toggle" type="button">Enable instrumentation</button>
+            <button id="instrument-clear" type="button">Clear log</button>
+            <button id="instrument-download" type="button">Download log JSON</button>
+            <button id="instrument-snippet" type="button">Copy DevTools snippet</button>
+        </div>
+        <p class="instrumentation-help">
+            Wraps <code>MediaDevices.prototype.enumerateDevices</code>,
+            <code>getUserMedia</code>, <code>getDisplayMedia</code> and
+            <code>Permissions.prototype.query</code> with a counter + stack
+            logger that sits <em>above</em> the C-S-S
+            <code>deviceEnumerationFix</code> proxy, so you can see every entry.
+            Use <strong>Copy DevTools snippet</strong> to paste the same
+            instrumentation into another site's DevTools (e.g.
+            <code>linkedin.com/checkpoint/...</code>) to observe what protechts /
+            reCAPTCHA / first-party scripts actually call.
+        </p>
+        <pre id="instrumentation-counts" class="instrumentation-counts"></pre>
+    </div>
+
     <div class="unleash-bar">
         <button id="unleash" type="button">Unleash chaos (run everything)</button>
         <span id="unleash-progress" class="unleash-progress"></span>

--- a/features/device-enumeration-chaos/index.html
+++ b/features/device-enumeration-chaos/index.html
@@ -69,6 +69,133 @@
             reCAPTCHA / first-party scripts actually call.
         </p>
         <pre id="instrumentation-counts" class="instrumentation-counts"></pre>
+
+        <details class="instrumentation-guide">
+            <summary>How to use this on a real site (e.g. linkedin.com) — full workflow</summary>
+
+            <h4>1. Install the snippet</h4>
+            <ol>
+                <li>Click <strong>Copy DevTools snippet</strong> above.</li>
+                <li>Open the site you want to observe (e.g.
+                    <code>https://www.linkedin.com/</code>) in the Windows
+                    DDG browser. For the OPS-7378 repro, temporarily disable
+                    the <code>protechts.net</code> request-blocklist rule so
+                    the checkpoint flow actually loads.</li>
+                <li>Open DevTools &rarr; Console. Paste the snippet and press
+                    Enter. You should see a red <code>chaos instrumentation
+                    installed</code> banner.</li>
+                <li>(Optional) Refresh the page so any scripts that probe
+                    early in page load are also observed.</li>
+            </ol>
+
+            <h4>2. Trigger the behaviour you want to observe</h4>
+            <p>
+                Navigate to / interact with the page as a tester would.
+                For the camera-prompt repro on LinkedIn, simply landing
+                on the <code>checkpoint</code> flow is usually enough.
+                The Console will stream <code>[chaos] &lt;API&gt; &lt;args&gt;
+                &lt;count&gt;</code> debug lines as each wrapped API is
+                called.
+            </p>
+
+            <h4>3. Read the counters</h4>
+            <pre>window.__chaosInstrumentation.summary()
+// { counts: { 'MediaDevices.enumerateDevices': 7, ... }, logCount: 7 }</pre>
+            <p>
+                Watch the call <em>rate</em>, not just the count. A normal
+                page calls <code>enumerateDevices</code> a handful of times
+                at most; an anti-bot fingerprinter calling it hundreds of
+                times in a few seconds is the queue-stampede pattern that
+                DaveV's A11 / A12 simulates.
+            </p>
+
+            <h4>4. What to look for</h4>
+            <ul>
+                <li>
+                    <strong><code>MediaDevices.enumerateDevices</code> count
+                        climbs into the hundreds within a few seconds.</strong>
+                    Likely the queue-stampede pattern. Under the C-S-S
+                    <code>deviceEnumerationFix</code> proxy this will start
+                    timing out (2000ms) and falling through to the real
+                    <code>enumerateDevices()</code> &mdash; which is what
+                    triggers the OS prompt on Windows MSIX.
+                </li>
+                <li>
+                    <strong>Any call to <code>MediaDevices.getUserMedia</code>
+                        without a user gesture.</strong> Almost always an
+                    anti-bot probe. Check the stack &mdash; if it points
+                    into <code>client.protechts.net/.../main.min.js</code>
+                    or <code>www.gstatic.com/recaptcha/...</code> that is
+                    your prompt trigger. The Asana investigation pointed
+                    here as the primary cause on linkedin.com.
+                </li>
+                <li>
+                    <strong><code>Permissions.query({name: 'camera'})</code>
+                        or <code>'microphone'</code></strong>. Informational;
+                    does not prompt on a normal browser. Still worth
+                    recording &mdash; if you see the count climb but no
+                    <code>getUserMedia</code> calls, the trigger may be
+                    elsewhere (or in a native-side path).
+                </li>
+                <li>
+                    <strong>Stacks containing <code>protechts.net</code>,
+                        <code>li.protechts.net</code>,
+                        <code>recaptcha/enterprise</code>,
+                        <code>static.licdn.com/aero-v1</code>.</strong>
+                    These are the candidate origins identified by the HAR
+                    analysis. Stacks pointing into LinkedIn's own
+                    <code>aero-v1</code> bundles are usually fine (gated
+                    behind user gestures); stacks pointing into protechts
+                    or recaptcha are the suspect entries.
+                </li>
+                <li>
+                    <strong>Empty or anonymous stack frames</strong>
+                    (common in obfuscated PerimeterX VM code). Cross-check
+                    the call timing against the Network panel &mdash; if
+                    the call lands within a few hundred ms of a
+                    <code>collector-pxdojv695v.protechts.net</code> POST,
+                    it is almost certainly from the protechts VM.
+                </li>
+            </ul>
+
+            <h4>5. Capture for the ticket</h4>
+            <pre>window.__chaosInstrumentation.download()  // saves full log + stacks as JSON
+window.__chaosInstrumentation.uninstall() // restore originals</pre>
+            <p>
+                Attach the downloaded JSON to OPS-7378 along with the
+                exact browser version and whether the OS prompt appeared.
+            </p>
+
+            <h4>What the snippet does <em>not</em> catch</h4>
+            <ul>
+                <li>
+                    Calls that resolve their function reference once and
+                    cache it before the snippet is pasted. Refresh after
+                    pasting to mitigate.
+                </li>
+                <li>
+                    Calls from a separate JavaScript realm
+                    (cross-origin iframes such as
+                    <code>li.protechts.net/index.html</code>). The
+                    snippet wraps only the top-level <code>MediaDevices</code>
+                    and <code>Permissions</code> prototypes. Calls from
+                    inside <code>li.protechts.net</code> happen in the
+                    iframe's own realm and are not visible to the top
+                    window. To observe those, paste the snippet into the
+                    iframe's own DevTools context (DevTools &rarr;
+                    iframe selector dropdown &rarr; pick the iframe), or
+                    use the
+                    <a href="../iframe-media-prompt.html">Iframe Media
+                        Prompt Repro</a> page which controls both sides.
+                </li>
+                <li>
+                    Native-side prompts that originate without a
+                    JavaScript entry point. If counts stay at zero but
+                    the OS prompt still fires, the trigger is upstream
+                    of the JS layer.
+                </li>
+            </ul>
+        </details>
     </div>
 
     <div class="unleash-bar">

--- a/features/device-enumeration-chaos/index.html
+++ b/features/device-enumeration-chaos/index.html
@@ -84,8 +84,40 @@
                 <li>Open DevTools &rarr; Console. Paste the snippet and press
                     Enter. You should see a red <code>chaos instrumentation
                     installed</code> banner.</li>
-                <li>(Optional) Refresh the page so any scripts that probe
-                    early in page load are also observed.</li>
+            </ol>
+            <p>
+                <strong>Important:</strong> the snippet does not survive a
+                page refresh &mdash; refresh creates a fresh
+                <code>window</code> / <code>MediaDevices.prototype</code> and
+                the wrappers are gone. Re-paste the snippet after every
+                refresh. To catch calls that fire <em>during</em> page load
+                (which is when most fingerprinting probes run), use the
+                pause-on-first-statement trick in the next section.
+            </p>
+
+            <h4>1b. Catching very early calls (pause before page JS runs)</h4>
+            <p>
+                Anti-bot scripts typically fire their probes within the first
+                few hundred ms of page load &mdash; before you can paste the
+                snippet manually. To guarantee the wrappers are in place
+                <em>before</em> any page JavaScript runs:
+            </p>
+            <ol>
+                <li>Open DevTools <em>before</em> loading the target page.</li>
+                <li>Go to <strong>Sources</strong> &rarr;
+                    <strong>Event Listener Breakpoints</strong> (right-hand
+                    pane). Expand <em>Script</em> and tick
+                    <strong>Script First Statement</strong>.</li>
+                <li>Navigate to / refresh the target site. DevTools will
+                    pause at the very first JavaScript statement.</li>
+                <li>Switch to the <strong>Console</strong> tab and paste the
+                    chaos snippet. The wrappers are now installed.</li>
+                <li>Click <strong>Resume script execution</strong> (▶ in
+                    Sources, or F8). All subsequent JS &mdash; including the
+                    protechts / reCAPTCHA bootstrap &mdash; will run through
+                    your wrappers.</li>
+                <li>Uncheck <em>Script First Statement</em> when you are
+                    done, otherwise every page load will pause.</li>
             </ol>
 
             <h4>2. Trigger the behaviour you want to observe</h4>

--- a/features/device-enumeration-chaos/main.js
+++ b/features/device-enumeration-chaos/main.js
@@ -461,6 +461,36 @@ const TECHNIQUES = [
             };
         },
     },
+    {
+        id: 'A11',
+        group: 'A',
+        title: 'enumerateDevices() x100 tight sync loop, fire-and-forget (DaveV repro)',
+        code: 'for (let i = 0; i < 100; i++) navigator.mediaDevices.enumerateDevices();',
+        async run() {
+            const unhandled = [];
+            const onUnhandled = (event) => {
+                unhandled.push(describeError(event.reason));
+                event.preventDefault();
+            };
+            window.addEventListener('unhandledrejection', onUnhandled);
+            const before = performance.now();
+            for (let i = 0; i < 100; i++) {
+                navigator.mediaDevices.enumerateDevices();
+            }
+            const syncReturnMs = Math.round(performance.now() - before);
+            await delay(2500);
+            window.removeEventListener('unhandledrejection', onUnhandled);
+            return {
+                fired: 100,
+                syncReturnMs,
+                unhandledRejectionsAfter2_5s: unhandled.length,
+                sampleUnhandled: unhandled.slice(0, 3),
+                hint: unhandled.length > 0
+                    ? 'Some calls rejected. Under the C-S-S deviceEnumerationFix the 2000ms native messaging timeout will fall back to the real enumerateDevices() — which is what triggers the OS prompt on Windows MSIX. Click this technique repeatedly to sustain the queue pressure.'
+                    : 'No unhandled rejections seen. If the OS prompt still appeared, the trigger is likely upstream of the shim or in a native-side path.',
+            };
+        },
+    },
 
     // Group B — getUserMedia probes (suspected actual trigger).
     // Each B technique stops the resulting stream immediately so the LED

--- a/features/device-enumeration-chaos/main.js
+++ b/features/device-enumeration-chaos/main.js
@@ -215,6 +215,197 @@ function collectIceCandidates(timeoutMs) {
     });
 }
 
+/*
+ * Instrumentation — wraps MediaDevices / Permissions APIs with counting+
+ * stack-capturing proxies so a tester can observe what's being called by
+ * either the chaos catalogue or, when the snippet is pasted into another
+ * site's DevTools, any other JS in the page (anti-bot scripts, fingerprint
+ * libraries, etc.). Wrappers are installed at MediaDevices.prototype /
+ * Permissions.prototype so they intercept calls regardless of which
+ * MediaDevices instance the caller uses, AND they sit on top of the C-S-S
+ * deviceEnumerationFix proxy (if present) so the tester sees every entry.
+ */
+const INSTRUMENTABLE = [
+    { proto: () => window.MediaDevices && window.MediaDevices.prototype, methods: ['enumerateDevices', 'getUserMedia', 'getDisplayMedia'] },
+    { proto: () => window.Permissions && window.Permissions.prototype, methods: ['query'] },
+];
+
+const instrumentation = {
+    enabled: false,
+    log: [],
+    counts: {},
+    /** @type {Array<{ proto: object, method: string, original: Function }>} */
+    originals: [],
+};
+
+function safeStack() {
+    try {
+        return new Error().stack || '';
+    } catch (e) {
+        return '';
+    }
+}
+
+function safeJson(value) {
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch (e) {
+        return String(value);
+    }
+}
+
+function instrumentApis() {
+    if (instrumentation.enabled) return;
+    instrumentation.enabled = true;
+    for (const target of INSTRUMENTABLE) {
+        const proto = target.proto();
+        if (!proto) continue;
+        for (const method of target.methods) {
+            const original = proto[method];
+            if (typeof original !== 'function') continue;
+            instrumentation.originals.push({ proto, method, original });
+            const key = `${proto.constructor.name}.${method}`;
+            instrumentation.counts[key] = 0;
+            proto[method] = function instrumentedMethod(...args) {
+                instrumentation.counts[key]++;
+                instrumentation.log.push({
+                    ts: Date.now(),
+                    api: key,
+                    args: safeJson(args),
+                    stack: safeStack(),
+                });
+                renderInstrumentationCounts();
+                return original.apply(this, args);
+            };
+        }
+    }
+    renderInstrumentationCounts();
+}
+
+function uninstrumentApis() {
+    if (!instrumentation.enabled) return;
+    for (const { proto, method, original } of instrumentation.originals) {
+        proto[method] = original;
+    }
+    instrumentation.originals = [];
+    instrumentation.enabled = false;
+    renderInstrumentationCounts();
+}
+
+function renderInstrumentationCounts() {
+    const el = document.getElementById('instrumentation-counts');
+    if (!el) return;
+    if (!instrumentation.enabled && Object.keys(instrumentation.counts).length === 0) {
+        el.textContent = '';
+        return;
+    }
+    const parts = Object.entries(instrumentation.counts)
+        .filter(([, n]) => n > 0)
+        .map(([k, n]) => `${k}=${n}`);
+    const prefix = instrumentation.enabled ? '[ON] ' : '[OFF] ';
+    el.textContent = `${prefix}${parts.join('  ')}${parts.length === 0 ? '(no calls yet)' : ''}`;
+}
+
+function clearInstrumentationLog() {
+    instrumentation.log = [];
+    for (const key of Object.keys(instrumentation.counts)) {
+        instrumentation.counts[key] = 0;
+    }
+    renderInstrumentationCounts();
+}
+
+function downloadInstrumentationLog() {
+    const payload = JSON.stringify({
+        enabled: instrumentation.enabled,
+        counts: instrumentation.counts,
+        log: instrumentation.log,
+        capturedAt: new Date().toISOString(),
+    }, null, 2);
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `device-enumeration-chaos-instrumentation-${Date.now()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+}
+
+/*
+ * Self-contained DevTools snippet — same instrumentation as the toggle above,
+ * but bundled into a single string that can be pasted into another site's
+ * DevTools console. Reports counts via window.__chaosInstrumentation and
+ * window.__chaosInstrumentation.log, plus prints a live summary to console
+ * on every call.
+ */
+const DEVTOOLS_SNIPPET = `(() => {
+    if (window.__chaosInstrumentation && window.__chaosInstrumentation.installed) {
+        console.log('chaos instrumentation already installed', window.__chaosInstrumentation);
+        return window.__chaosInstrumentation;
+    }
+    const targets = [
+        { proto: window.MediaDevices && window.MediaDevices.prototype, methods: ['enumerateDevices', 'getUserMedia', 'getDisplayMedia'] },
+        { proto: window.Permissions && window.Permissions.prototype, methods: ['query'] },
+    ];
+    const state = { installed: true, counts: {}, log: [], originals: [] };
+    for (const t of targets) {
+        if (!t.proto) continue;
+        for (const m of t.methods) {
+            const original = t.proto[m];
+            if (typeof original !== 'function') continue;
+            state.originals.push({ proto: t.proto, method: m, original });
+            const key = t.proto.constructor.name + '.' + m;
+            state.counts[key] = 0;
+            t.proto[m] = function (...args) {
+                state.counts[key]++;
+                let stack = '';
+                try { stack = new Error().stack || ''; } catch (e) {}
+                let argsCopy;
+                try { argsCopy = JSON.parse(JSON.stringify(args)); } catch (e) { argsCopy = String(args); }
+                state.log.push({ ts: Date.now(), api: key, args: argsCopy, stack });
+                console.debug('[chaos]', key, argsCopy, state.counts[key]);
+                return original.apply(this, args);
+            };
+        }
+    }
+    state.uninstall = () => {
+        for (const { proto, method, original } of state.originals) proto[method] = original;
+        state.installed = false;
+        console.log('chaos instrumentation uninstalled');
+    };
+    state.summary = () => ({ counts: { ...state.counts }, logCount: state.log.length });
+    state.download = () => {
+        const json = JSON.stringify({ counts: state.counts, log: state.log, capturedAt: new Date().toISOString() }, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'chaos-instrumentation-' + Date.now() + '.json';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+    };
+    window.__chaosInstrumentation = state;
+    console.log('%cchaos instrumentation installed', 'background:#a31515;color:#fff;padding:2px 6px;border-radius:3px',
+        '\\nCalls log: window.__chaosInstrumentation.log',
+        '\\nLive counts: window.__chaosInstrumentation.summary()',
+        '\\nDownload JSON: window.__chaosInstrumentation.download()',
+        '\\nUninstall: window.__chaosInstrumentation.uninstall()');
+    return state;
+})();`;
+
+async function copyDevToolsSnippet() {
+    try {
+        await navigator.clipboard.writeText(DEVTOOLS_SNIPPET);
+        log('DevTools snippet copied to clipboard');
+    } catch (e) {
+        log('Clipboard write failed, snippet printed to console:', describeError(e));
+        console.log(DEVTOOLS_SNIPPET);
+    }
+}
+
 function collectDiagnostics() {
     const md = navigator.mediaDevices;
     const enumerateFnSource = md && md.enumerateDevices ? Function.prototype.toString.call(md.enumerateDevices) : null;
@@ -488,6 +679,53 @@ const TECHNIQUES = [
                 hint: unhandled.length > 0
                     ? 'Some calls rejected. Under the C-S-S deviceEnumerationFix the 2000ms native messaging timeout will fall back to the real enumerateDevices() — which is what triggers the OS prompt on Windows MSIX. Click this technique repeatedly to sustain the queue pressure.'
                     : 'No unhandled rejections seen. If the OS prompt still appeared, the trigger is likely upstream of the shim or in a native-side path.',
+            };
+        },
+    },
+    {
+        id: 'A12',
+        group: 'A',
+        title: 'Sustained queue-stampede probe (50 fire-and-forget enumerateDevices() per 100ms for 3s)',
+        code: 'setInterval(() => { for (i=0; i<50; i++) enumerateDevices(); }, 100) for 3s = ~1500 calls',
+        async run() {
+            const unhandled = [];
+            const onUnhandled = (event) => {
+                unhandled.push(describeError(event.reason));
+                event.preventDefault();
+            };
+            window.addEventListener('unhandledrejection', onUnhandled);
+            const ticks = 30;
+            const perTick = 50;
+            let calls = 0;
+            const started = performance.now();
+            await new Promise((resolve) => {
+                let tick = 0;
+                const id = setInterval(() => {
+                    tick++;
+                    for (let i = 0; i < perTick; i++) {
+                        try {
+                            navigator.mediaDevices.enumerateDevices();
+                            calls++;
+                        } catch (e) {
+                            unhandled.push(describeError(e));
+                        }
+                    }
+                    if (tick >= ticks) {
+                        clearInterval(id);
+                        resolve();
+                    }
+                }, 100);
+            });
+            await delay(2500);
+            window.removeEventListener('unhandledrejection', onUnhandled);
+            return {
+                callsFired: calls,
+                durationMs: Math.round(performance.now() - started),
+                ticks,
+                perTick,
+                unhandledRejections: unhandled.length,
+                sampleUnhandled: unhandled.slice(0, 3),
+                hint: 'A sustained-rate variant of A11 that more closely matches what a real anti-bot fingerprinter might do over a probe window. Watch the OS-prompt selector and the instrumentation counter at the top of the page (enable instrumentation first to see exact call counts and stack traces).',
             };
         },
     },
@@ -1068,6 +1306,30 @@ function renderDiagnostics() {
     }
 }
 
+const instrumentToggleButton = document.getElementById('instrument-toggle');
+const instrumentClearButton = document.getElementById('instrument-clear');
+const instrumentDownloadButton = document.getElementById('instrument-download');
+const instrumentSnippetButton = document.getElementById('instrument-snippet');
+
+function updateInstrumentToggleLabel() {
+    instrumentToggleButton.textContent = instrumentation.enabled
+        ? 'Disable instrumentation'
+        : 'Enable instrumentation';
+    instrumentToggleButton.classList.toggle('active', instrumentation.enabled);
+}
+
+instrumentToggleButton.addEventListener('click', () => {
+    if (instrumentation.enabled) {
+        uninstrumentApis();
+    } else {
+        instrumentApis();
+    }
+    updateInstrumentToggleLabel();
+});
+instrumentClearButton.addEventListener('click', clearInstrumentationLog);
+instrumentDownloadButton.addEventListener('click', downloadInstrumentationLog);
+instrumentSnippetButton.addEventListener('click', copyDevToolsSnippet);
+
 unleashButton.addEventListener('click', () => {
     confirmDialog.showModal();
 });
@@ -1107,4 +1369,6 @@ function renderEnvironmentWarnings() {
 renderDiagnostics();
 renderEnvironmentWarnings();
 renderTechniques();
+updateInstrumentToggleLabel();
+renderInstrumentationCounts();
 log(`Ready — ${TECHNIQUES.length} techniques loaded.`);

--- a/features/device-enumeration-chaos/style.css
+++ b/features/device-enumeration-chaos/style.css
@@ -89,6 +89,50 @@ input {
     padding: 10px 12px;
 }
 
+.instrumentation-bar {
+    background: #eef6ff;
+    border: 1px solid #5b9bd5;
+    border-radius: 4px;
+    margin: 12px 0;
+    padding: 10px 12px;
+}
+
+.instrumentation-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.instrumentation-controls button {
+    cursor: pointer;
+    padding: 6px 12px;
+}
+
+.instrumentation-controls button.active {
+    background: #1f6feb;
+    border: 1px solid #1158c7;
+    color: #fff;
+    font-weight: 700;
+}
+
+.instrumentation-help {
+    color: #234;
+    font-size: 13px;
+    margin: 8px 0 4px;
+}
+
+.instrumentation-counts {
+    background: #0e1626;
+    border-radius: 4px;
+    color: #cfe2ff;
+    font-size: 12px;
+    margin: 6px 0 0;
+    min-height: 18px;
+    overflow-x: auto;
+    padding: 8px 10px;
+    white-space: pre-wrap;
+}
+
 .diagnostic dl {
     display: grid;
     gap: 4px 12px;

--- a/features/device-enumeration-chaos/style.css
+++ b/features/device-enumeration-chaos/style.css
@@ -133,6 +133,44 @@ input {
     white-space: pre-wrap;
 }
 
+.instrumentation-guide {
+    background: #fff;
+    border: 1px solid #b6d0ee;
+    border-radius: 4px;
+    margin-top: 10px;
+    padding: 6px 12px;
+}
+
+.instrumentation-guide summary {
+    cursor: pointer;
+    font-weight: 700;
+    padding: 4px 0;
+}
+
+.instrumentation-guide h4 {
+    margin: 14px 0 4px;
+}
+
+.instrumentation-guide pre {
+    background: #f6f6f6;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    font-size: 12px;
+    margin: 4px 0;
+    overflow-x: auto;
+    padding: 6px 8px;
+}
+
+.instrumentation-guide ul,
+.instrumentation-guide ol {
+    margin: 4px 0 8px;
+    padding-left: 22px;
+}
+
+.instrumentation-guide li {
+    margin-bottom: 4px;
+}
+
 .diagnostic dl {
     display: grid;
     gap: 4px 12px;


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/949243614371883/task/1214933948986277?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are isolated to a standalone repro/test page, adding optional prototype-wrapping instrumentation and a couple of new test techniques without affecting production runtime.
> 
> **Overview**
> Adds an *optional instrumentation mode* to `device-enumeration-chaos` that wraps `MediaDevices`/`Permissions` prototype APIs to record per-call counters, arguments, and stack traces, with UI controls to toggle, clear, download JSON logs, and copy a self-contained DevTools snippet for use on real sites.
> 
> Extends the technique catalogue with two new `enumerateDevices()` stress probes (`A11`/`A12`) to simulate tight-loop and sustained “queue stampede” calling patterns, and adds styling/help text to guide testers through capture and analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5713c0512565e277c0a23334134e8a74ed5356f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->