### PR TITLE
Add F1 passkeys + enumerateDevices repro (LinkedIn camera prompt)

### DIFF
--- a/features/device-enumeration-chaos/index.html
+++ b/features/device-enumeration-chaos/index.html
@@ -35,6 +35,13 @@
             in-app permission UI.
         </p>
         <p>
+            <strong>LinkedIn + Passkeys repro (F1).</strong> On linkedin.com the OS camera prompt was traced to
+            <code>enumerateDevices()</code> starting while a Passkeys WebAuthn dialog was open; the
+            <code>deviceEnumerationFix</code> shim timed out after 2s and called the real API. Technique
+            <strong>F1</strong> reproduces that sequence — <em>Passkeys / Windows Hello must be enabled</em>
+            on the test machine or the WebAuthn prompt will not appear and the repro will not match production.
+        </p>
+        <p>
             For the cross-origin third-party iframe scenario (the actual shape protechts.net /
             HUMAN Security takes on linkedin.com — top-level page in one origin, fingerprinting iframe in
             another with <code>allow="camera; microphone"</code>), use the existing

--- a/features/device-enumeration-chaos/main.js
+++ b/features/device-enumeration-chaos/main.js
@@ -418,6 +418,7 @@ function collectDiagnostics() {
         hasLegacyGetUserMedia: typeof navigator.getUserMedia === 'function',
         hasPermissionsApi: Boolean(navigator.permissions && navigator.permissions.query),
         hasRTCPeerConnection: typeof window.RTCPeerConnection === 'function',
+        hasPublicKeyCredential: typeof window.PublicKeyCredential === 'function',
         crossOriginIsolated: Boolean(window.crossOriginIsolated),
         isSecureContext: Boolean(window.isSecureContext),
         enumerateDevicesAppearsNative: enumerateFnSource ? /\[native code\]/.test(enumerateFnSource) : null,
@@ -1112,6 +1113,53 @@ const TECHNIQUES = [
             return { steps: results };
         },
     },
+    {
+        id: 'F1',
+        group: 'F',
+        title: 'LinkedIn passkeys + enumerateDevices (deviceEnumerationFix timeout repro)',
+        note:
+            'Requires Passkeys / Windows Hello to be enabled on the test machine. '
+            + 'Fires enumerateDevices() then immediately opens the WebAuthn "Would you like to use Passkeys?" prompt. '
+            + 'If that prompt stays open for more than ~2s, the C-S-S deviceEnumerationFix shim times out and falls through to the real enumerateDevices(), '
+            + 'which can trigger the Windows OS camera prompt (the linkedin.com bug). '
+            + 'Leave the Passkeys dialog open for >2s to repro; dismiss within 2s to verify the fix.',
+        code:
+            'enumerateDevices(); credentials.get({ publicKey: { challenge: new Uint8Array(32), timeout: 60000, userVerification: "preferred" }, mediation: "optional" })',
+        async run() {
+            if (typeof PublicKeyCredential !== 'function') {
+                throw new Error('PublicKeyCredential-unavailable — enable Passkeys / WebAuthn on this browser');
+            }
+            const startedAt = performance.now();
+            const enumeratePromise = navigator.mediaDevices.enumerateDevices();
+            const credentialsPromise = navigator.credentials.get({
+                publicKey: {
+                    challenge: new Uint8Array(32),
+                    timeout: 60000,
+                    userVerification: 'preferred',
+                },
+                mediation: 'optional',
+            });
+            const [enumerateResult, credentialsResult] = await Promise.allSettled([
+                enumeratePromise,
+                credentialsPromise,
+            ]);
+            const durationMs = Math.round(performance.now() - startedAt);
+            const enumerate = enumerateResult.status === 'fulfilled'
+                ? { ok: true, count: enumerateResult.value.length, kinds: enumerateResult.value.map((d) => d.kind) }
+                : { ok: false, error: describeError(enumerateResult.reason) };
+            const credentials = credentialsResult.status === 'fulfilled'
+                ? { ok: true, type: credentialsResult.value?.type ?? null }
+                : { ok: false, error: describeError(credentialsResult.reason) };
+            return {
+                durationMs,
+                enumerate,
+                credentials,
+                hint:
+                    'Watch for the OS camera prompt while the Passkeys dialog is still open. '
+                    + 'enumerateDevices settling after ~2000ms with the Passkeys UI visible strongly suggests the shim timed out.',
+            };
+        },
+    },
 ];
 
 const GROUPS = [
@@ -1159,6 +1207,12 @@ function renderTechniques() {
             codeEl.textContent = tech.code;
             meta.appendChild(titleEl);
             meta.appendChild(codeEl);
+            if (tech.note) {
+                const noteEl = document.createElement('p');
+                noteEl.className = 'tech-note';
+                noteEl.textContent = tech.note;
+                meta.appendChild(noteEl);
+            }
 
             const status = document.createElement('div');
             status.className = 'tech-status';

--- a/features/device-enumeration-chaos/style.css
+++ b/features/device-enumeration-chaos/style.css
@@ -239,6 +239,13 @@ input {
     word-break: break-all;
 }
 
+.tech-note {
+    color: #5b3d00;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 13px;
+    margin: 6px 0 0;
+}
+
 .tech-button {
     background: #fff;
     border: 1px solid #888;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds technique **F1** to the [Device Enumeration Chaos](https://privacy-test-pages.site/features/device-enumeration-chaos/) page to reproduce the linkedin.com OS camera prompt scenario:

1. `navigator.mediaDevices.enumerateDevices()` starts (C-S-S `deviceEnumerationFix` shim begins its 2s timeout)
2. `navigator.credentials.get({ publicKey: … })` immediately opens the Passkeys WebAuthn dialog
3. If the Passkeys UI stays open for >2s, the shim falls through to the real `enumerateDevices()` and can trigger the Windows OS camera prompt

## How to test

1. On a Windows DDG build with Passkeys / Windows Hello **enabled**
2. Open `/features/device-enumeration-chaos/` and run **F1**
3. When the Passkeys dialog appears, **wait >2 seconds** before dismissing — observe whether the OS camera prompt appears
4. Re-run and dismiss Passkeys within 2s to verify the fix path

Also documents the Passkeys requirement in the page banner and an inline note on the F1 row.

## Checklist

- [x] `npm test` (ESLint) passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6497270d-1e49-4a95-947b-1a478353f601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6497270d-1e49-4a95-947b-1a478353f601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

