### PR TITLE
add some x-safari-http scheme related pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
 	<li><a href='./content-scope-scripts/'>C-S-S core tests</a></li>
 	<li><a href='./content-scope-scripts/element-hiding/'>Element Hiding (C-S-S)</a></li>
 	<li><a href='./tools/reach-calculator.html'>Site Breakage Reach Calculator</a></li>
+	<li><a href='./x-safari-scheme/index.html'>x-safari-http(s) Scheme</a></li>
 </ul>
 
 </body>

--- a/x-safari-scheme/index.html
+++ b/x-safari-scheme/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>x-safari-http(s) scheme links</title>
+</head>
+<body>
+<ul id="links"></ul>
+
+<script>
+  const host = window.location.hostname;
+  const port = window.location.port;
+  const hostPort = port ? `${host}:${port}` : host;
+
+  const links = [
+    { scheme: "x-safari-http",  file: "noloop.html", label: "http no loop" },
+    { scheme: "x-safari-https", file: "noloop.html", label: "https no loop" },
+    { scheme: "x-safari-http",  file: "loop.html",   label: "http with loop" },
+    { scheme: "x-safari-https", file: "loop.html",   label: "https with loop" },
+  ];
+
+  const ul = document.getElementById("links");
+  links.forEach(({ scheme, file, label }) => {
+    const li = document.createElement("li");
+    const a = document.createElement("a");
+    a.href = `${scheme}://${hostPort}/${file}`;
+    a.textContent = label;
+    li.appendChild(a);
+    ul.appendChild(li);
+  });
+</script>
+</body>
+</html>

--- a/x-safari-scheme/loop.html
+++ b/x-safari-scheme/loop.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>x-safari-https redirect</title>
+  <script>
+    const { hostname, port, pathname, search } = window.location;
+    const hostPort = port ? `${hostname}:${port}` : hostname;
+    window.location.replace(`x-safari-https://${hostPort}${pathname}${search}`);
+  </script>
+</head>
+<body>
+</body>
+</html>

--- a/x-safari-scheme/loop.html
+++ b/x-safari-scheme/loop.html
@@ -11,5 +11,9 @@
   </script>
 </head>
 <body>
+	<h1>Looping</h1>
+
+	In theory you should never see this page.
+	
 </body>
 </html>

--- a/x-safari-scheme/noloop.html
+++ b/x-safari-scheme/noloop.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>x-safari-http(s) scheme links</title>
+</head>
+<body>
+
+<h1>No loop</h1>
+
+If x-safari-http(s) is supported then this should have opened in Safari.
+
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Static HTML test fixtures and a single index link; no production app or security logic changes.
> 
> **Overview**
> Adds a new **`x-safari-scheme/`** test area and links it from the home page under **Other**.
> 
> The hub page builds four links against the current host/port using **`x-safari-http`** and **`x-safari-https`**, pointing at **`noloop.html`** (static page that indicates success if the URL opened in Safari) and **`loop.html`** (immediately **`location.replace`**s to **`x-safari-https`** with the same path/query to exercise redirect/loop handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7fdaeff93912d8d51f61678b19c65128a70021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->