### PR TITLE
x-safari loop page: don't redirect when on Safari

### DIFF
--- a/x-safari-scheme/loop.html
+++ b/x-safari-scheme/loop.html
@@ -5,15 +5,28 @@
   <meta name="viewport" content="width=device-width">
   <title>x-safari-https redirect</title>
   <script>
-    const { hostname, port, pathname, search } = window.location;
-    const hostPort = port ? `${hostname}:${port}` : hostname;
-    window.location.replace(`x-safari-https://${hostPort}${pathname}${search}`);
+    (function () {
+      const ua = navigator.userAgent;
+
+      // Safari's UA includes "Safari" but so do Chrome, Edge, Opera, etc.
+      // Real Safari has "Safari/" but NOT any of: Chrome, Chromium, CriOS,
+      // FxiOS, EdgiOS, OPR, OPiOS, Android.
+      const regex = /Safari\/\S+$/;
+      const isSafari = regex.test(ua)
+
+      if (isSafari) {
+        // Already in Safari — don't redirect, just show the page.
+        return;
+      }
+
+      const { hostname, port, pathname, search } = window.location;
+      const hostPort = port ? `${hostname}:${port}` : hostname;
+      window.location.replace(`x-safari-https://${hostPort}${pathname}${search}`);
+    })();
   </script>
 </head>
 <body>
-	<h1>Looping</h1>
-
-	In theory you should never see this page.
-	
+  <h1>Looping</h1>
+  In theory you should never see this page unless you're already in Safari.
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change to a test/demo HTML page with no auth, data, or production app logic.
> 
> **Overview**
> The **loop** test page in `x-safari-scheme` used to always `location.replace` to `x-safari-https://…`, which could loop when the page was already opened in Safari.
> 
> The redirect script is now wrapped in an IIFE that **skips the redirect when the user agent looks like Safari** (`/Safari\/\S+$/`), with comments noting that other browsers also include “Safari” in the UA. Non-Safari clients still get the same `x-safari-https` handoff. Body copy and whitespace were tweaked to say the page is only expected to be visible in Safari.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e444523e27ba445b5dadbf67c1a3f9363ae6ab76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->