### PR TITLE
more x-safari-https related page updates

### DIFF
--- a/x-safari-scheme/alwaysloop.html
+++ b/x-safari-scheme/alwaysloop.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>x-safari-https redirect</title>
+  <script>
+    (function () {
+      // Only loop in our browser
+      if (!navigator.duckduckgo) {
+        return
+      }
+
+      const { hostname, port, pathname, search } = window.location;
+      const hostPort = port ? `${hostname}:${port}` : hostname;
+      window.location.replace(`x-safari-https://${hostPort}${pathname}${search}`);
+    })();
+  </script>
+</head>
+<body>
+  <h1>Looping</h1>
+  This page redirects to x-safari-https:// if the browser is Duckduckgo (navigator.duckduckgo != null)
+</body>
+</html>

--- a/x-safari-scheme/index.html
+++ b/x-safari-scheme/index.html
@@ -15,10 +15,9 @@
   const dir = window.location.pathname.replace(/\/[^/]*$/, '/');
 
   const links = [
-    { scheme: "x-safari-http",  file: "noloop.html", label: "http no loop" },
-    { scheme: "x-safari-https", file: "noloop.html", label: "https no loop" },
-    { scheme: "x-safari-http",  file: "loop.html",   label: "http with loop" },
-    { scheme: "x-safari-https", file: "loop.html",   label: "https with loop" },
+    { scheme: "x-safari-https", file: "noloop.html", label: "direct link, no loop" },
+    { scheme: "x-safari-https", file: "loop.html",   label: "direct link, then loops while not safari" },
+    { scheme: "x-safari-https", file: "alwaysloop.html",   label: "direct link, then loops while in DuckDuckGo explicitly" },
   ];
 
   const ul = document.getElementById("links");

--- a/x-safari-scheme/loop.html
+++ b/x-safari-scheme/loop.html
@@ -27,6 +27,6 @@
 </head>
 <body>
   <h1>Looping</h1>
-  In theory you should never see this page unless you're already in Safari.
+  This page redirects to x-safari-https:// if the user agent is not Safari.
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Static HTML test pages with no production app, auth, or data handling changes.
> 
> **Overview**
> Refines the **x-safari-scheme** manual test harness around **`x-safari-https`** only and adds a DuckDuckGo-specific redirect case.
> 
> **`index.html`** no longer lists **`x-safari-http`** or paired http/https entries; it now exposes three **`x-safari-https`** links (`noloop`, `loop`, `alwaysloop`) with labels that describe whether each page loops and under what condition.
> 
> **`alwaysloop.html`** is new: it **`location.replace`s** to the same URL on the **`x-safari-https`** scheme only when **`navigator.duckduckgo`** is present, so engineers can exercise redirect behavior inside the DuckDuckGo browser without relying on Safari UA detection.
> 
> **`loop.html`** only updates the visible explanation to state that redirect happens when the user agent is not Safari (logic unchanged in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dacf60d0d5e31430a62a85c913944ce5870e3383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->