### PR TITLE
x-safari just make looping page do it forever

### DIFF
--- a/x-safari-scheme/alwaysloop.html
+++ b/x-safari-scheme/alwaysloop.html
@@ -6,11 +6,7 @@
   <title>x-safari-https redirect</title>
   <script>
     (function () {
-      // Only loop in our browser
-      if (!navigator.duckduckgo) {
-        return
-      }
-
+      // This page always loops (even in Safari)
       const { hostname, port, pathname, search } = window.location;
       const hostPort = port ? `${hostname}:${port}` : hostname;
       window.location.replace(`x-safari-https://${hostPort}${pathname}${search}`);
@@ -19,6 +15,6 @@
 </head>
 <body>
   <h1>Looping</h1>
-  This page redirects to x-safari-https:// if the browser is Duckduckgo (navigator.duckduckgo != null)
+  This page always redirects to x-safari-https:// even in safari.
 </body>
 </html>

--- a/x-safari-scheme/index.html
+++ b/x-safari-scheme/index.html
@@ -17,7 +17,7 @@
   const links = [
     { scheme: "x-safari-https", file: "noloop.html", label: "direct link, no loop" },
     { scheme: "x-safari-https", file: "loop.html",   label: "direct link, then loops while not safari" },
-    { scheme: "x-safari-https", file: "alwaysloop.html",   label: "direct link, then loops while in DuckDuckGo explicitly" },
+    { scheme: "x-safari-https", file: "alwaysloop.html",   label: "direct link, always loops, even in safari!" },
   ];
 
   const ul = document.getElementById("links");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change to static HTML test fixtures for the x-safari scheme; no production app or security logic.
> 
> **Overview**
> The **`alwaysloop.html`** test page no longer gates redirects on `navigator.duckduckgo`; it **always** issues `window.location.replace` to `x-safari-https://`, including in Safari.
> 
> Copy and the **`index.html`** link label were updated to describe that behavior (previously it only looped in DuckDuckGo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2b0766058ad66addcd601b9bec11491c9637eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->