### PR TITLE
add page with element pinned to bottom

### DIFF
--- a/viewport/bottom-pinned.html
+++ b/viewport/bottom-pinned.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bottom Fixed Bar</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      min-height: 200vh; /* just to show scrolling */
+    }
+
+    .content {
+      padding: 24px;
+      padding-bottom: 80px; /* prevents content from hiding behind bar */
+    }
+
+    .bottom-bar {
+      position: fixed;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      height: 60px;
+      background: #222;
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 -2px 8px rgba(0,0,0,0.2);
+    }
+  </style>
+</head>
+<body>
+  <div class="content">
+    <h1>Page Content</h1>
+    <p>Scroll down — the bar stays pinned to the bottom of the screen.</p>
+  </div>
+
+  <div class="bottom-bar">
+    Fixed bottom bar
+  </div>
+</body>
+</html>

--- a/viewport/index.html
+++ b/viewport/index.html
@@ -24,5 +24,8 @@
       <li><a href="viewport-multiple-tags.html">multiple viewport tags</a></li>
       <li><a href="viewport-conflicting-tags.html">conflicting viewport tags</a></li>
     </ul>
+
+    <p>There is also <a href="bottom-pinned.html">a bottom pinned element</a> which can be used for testing view port changes.</p>
+
   </body>
 </html>


### PR DESCRIPTION
Can be used for testing viewport changes on scroll.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static HTML test fixtures only; no application logic or runtime behavior changes.
> 
> **Overview**
> Adds **`viewport/bottom-pinned.html`**, a standalone demo page with tall scrollable content and a **`position: fixed`** bottom bar (plus bottom padding so content isn’t obscured), intended for manual viewport/scroll behavior testing.
> 
> **`viewport/index.html`** now links to that page from the viewport test cases index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2111273ae08e48da3d656ed0cefaee8fcd51a1dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->