### PR TITLE
add more element pinning examples

### DIFF
--- a/viewport/index.html
+++ b/viewport/index.html
@@ -25,7 +25,12 @@
       <li><a href="viewport-conflicting-tags.html">conflicting viewport tags</a></li>
     </ul>
 
-    <p>There is also <a href="bottom-pinned.html">a bottom pinned element</a> which can be used for testing view port changes.</p>
+    <h2>Element Pinning</h2>
 
+    <ul>
+      <li><a href="bottom-pinned.html">bottom pinned elements</a></li>
+      <li><a href="top-pinned.html">top pinned elements</a></li>
+    </ul>
+    
   </body>
 </html>

--- a/viewport/top-pinned.html
+++ b/viewport/top-pinned.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticky Top Bar Example</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      line-height: 1.5;
+    }
+
+    .top-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: #1f2937;
+      color: white;
+      display: flex;
+      align-items: center;
+      padding: 0 20px;
+      z-index: 1000;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    }
+
+    .content {
+      padding: 80px 20px 20px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    .section {
+      margin-bottom: 40px;
+      padding: 20px;
+      background: #f3f4f6;
+      border-radius: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="top-bar">
+    My Pinned Top Bar
+  </div>
+
+  <div class="content">
+    <div class="section">
+      <h1>Page Title</h1>
+      <p>This content starts below the fixed top bar.</p>
+    </div>
+
+    <div class="section">
+      <h2>Section 1</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+
+    <div class="section">
+      <h2>Section 2</h2>
+      <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </div>
+
+    <div class="section">
+      <h2>Section 3</h2>
+      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</p>
+    </div>
+
+    <div class="section">
+      <h2>Section 4</h2>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.</p>
+    </div>
+
+    <div class="section">
+      <h2>Section 5</h2>
+      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.</p>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Static HTML test fixtures and index navigation only; no application or runtime logic changes.
> 
> **Overview**
> Adds a **top fixed bar** manual test page (`top-pinned.html`) alongside the existing bottom-pinned example, using `position: fixed` at the top with padded scrollable content below.
> 
> Updates **`viewport/index.html`** so element pinning is a dedicated **Element Pinning** section with links to both bottom- and top-pinned fixtures, instead of a single inline mention of the bottom page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 698f5c6c31b509f9ef4011827b58973c5537b1c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->