### PR TITLE
add navigable links for xsafari

### DIFF
--- a/x-safari-scheme/index.html
+++ b/x-safari-scheme/index.html
@@ -30,5 +30,14 @@
     ul.appendChild(li);
   });
 </script>
+
+
+<h2>Navigation Links</h2>
+
+<ul>
+<li> <a href="https://x.com/DuckDuckGo/status/2060418373318553902">https://x.com (DuckDuckGo post)</a> </li>
+<li> <a href="https://redirect.x.com/DuckDuckGo/status/2060418373318553902">https://redirect.x.com (DDG post)</a></li>
+</ul>
+
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-page HTML only; no app logic, auth, or data handling changes.
> 
> **Overview**
> Adds a **Navigation Links** section to `x-safari-scheme/index.html` with two static anchors for manual x-safari / redirect testing.
> 
> One link targets `https://x.com/...` and the other `https://redirect.x.com/...`, both pointing at the same DuckDuckGo status URL so testers can compare normal vs redirect host behavior from the existing scheme test page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548677b083c31ee0aefde2312134870363760068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->